### PR TITLE
fix: commitlint実行コマンドをyarnからnpmに変更

### DIFF
--- a/commit-msg
+++ b/commit-msg
@@ -3,4 +3,4 @@ set -eu
 
 script_dir=$(dirname "$0")
 commit_editmsg_file="$(realpath "${1}")"
-yarn --cwd "$script_dir" commitlint --edit "$commit_editmsg_file"
+npm --prefix "$script_dir" exec -- commitlint --edit "$commit_editmsg_file"


### PR DESCRIPTION
全体をyarnからnpmに移行したのに、
ここを見落としていたため修正。
