### PR TITLE
fix(home-manager): git設定のcore.hooksPath定義方法を修正

### DIFF
--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -23,6 +23,6 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    programs.git.extraConfig.core.hooksPath = "${cfg.package}/lib/git-hooks";
+    programs.git.settings.core.hooksPath = "${cfg.package}/lib/git-hooks";
   };
 }


### PR DESCRIPTION
新しいバージョンのhome-managerに対応。
