### PR TITLE
fix(commit-msg): commitlint設定ファイルのパス指定を追加

### DIFF
--- a/commit-msg
+++ b/commit-msg
@@ -3,4 +3,4 @@ set -eu
 
 script_dir=$(dirname "$0")
 commit_editmsg_file="$(realpath "${1}")"
-npm --prefix "$script_dir" exec -- commitlint --edit "$commit_editmsg_file"
+npm --prefix "$script_dir" exec -- commitlint --config "$script_dir/commitlint.config.ts" --edit "$commit_editmsg_file"


### PR DESCRIPTION
- commitlint実行時に--configオプションで設定ファイルを明示的に指定
- 設定ファイルのパスをscript_dir/commitlint.config.tsに変更
