### PR TITLE
ci: dependabotで@types/nodeのマイナー・メジャー更新を無視する設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,8 @@ updates:
       commitlint:
         patterns:
           - "*commitlint*"
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"


### PR DESCRIPTION
Node.jsのメジャーバージョンは流石にNixもからむし、
手動で管理したいため。
patchは型定義のバグ修正とかだったりすることが多いしいいよ。
