### PR TITLE
build: nixpkgsの標準のnodejsを使用

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
           ...
         }:
         let
-          nodejs = pkgs.nodejs_24;
+          inherit (pkgs) nodejs;
 
           npmRoot = lib.fileset.toSource {
             root = ./.;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       "devDependencies": {
         "@eslint/compat": "^2",
         "@eslint/js": "^10",
-        "@types/node": "^24",
+        "@types/node": "^22",
         "eslint": "^10",
         "eslint-config-prettier": "^10",
         "eslint-import-resolver-typescript": "^4",
@@ -26,7 +26,7 @@
         "typescript-eslint": "^8"
       },
       "engines": {
-        "node": ">=24"
+        "node": ">=22.22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -628,12 +628,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2891,9 +2891,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@eslint/compat": "^2",
     "@eslint/js": "^10",
-    "@types/node": "^24",
+    "@types/node": "^22",
     "eslint": "^10",
     "eslint-config-prettier": "^10",
     "eslint-import-resolver-typescript": "^4",
@@ -32,6 +32,6 @@
     "typescript-eslint": "^8"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=22.22"
   }
 }


### PR DESCRIPTION
上流での依存関係の合わせとかが面倒くさかったので。
どうせそんな高度な機能は使っていないので一番安定しているバージョンを使います。
mainのaliasを使ってもflake.lockで管理されているので、
これ自体の依存関係は気にしなくていい。
