### PR TITLE
feat: コミットの行幅制限を有効にする

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -6,9 +6,13 @@ const rules: Partial<RulesConfig & UserRulesConfig> = {
   // 日本語なども含めた可読文字で終わることを求める。
   "subject-alnum-stop": [RuleConfigSeverity.Error, "never"],
 
-  // URLやMarkdownのリンクなど改行出来ない要素が頻繁に出現するため緩める。
-  "body-max-line-length": [RuleConfigSeverity.Disabled],
-  "footer-max-line-length": [RuleConfigSeverity.Disabled],
+  // 件名の長さはGit公式推奨の50文字は厳しすぎるのである程度緩和します。
+  "header-max-length": [RuleConfigSeverity.Error, "always", 72],
+
+  // 本文の1行幅はGit公式推奨の72文字は現代のターミナルを考えると厳しすぎるので100文字まで。
+  "body-max-line-length": [RuleConfigSeverity.Error, "always", 100],
+  "footer-max-line-length": [RuleConfigSeverity.Error, "always", 100],
+
   // 関数などの識別子などを直接コミットメッセージのタイトルに書きたいので無効にする。
   "subject-case": [RuleConfigSeverity.Disabled],
 };


### PR DESCRIPTION
[feat(rules): make body-max-line-length ignore lines with URLs by aspiers · Pull Request #4486 · conventional-changelog/commitlint](https://github.com/conventional-changelog/commitlint/pull/4486)
でURLを含む行は行数制限の対象外となったため、
素直に行数制限を有効にして問題なくなりました。
close #79
