### PR TITLE
build: devDependenciesのバージョン指定を具体的なバージョンに更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,19 +11,19 @@
         "@commitlint/types": "^20.5.0"
       },
       "devDependencies": {
-        "@eslint/compat": "^2",
-        "@eslint/js": "^10",
-        "@types/node": "^22",
-        "eslint": "^10",
-        "eslint-config-prettier": "^10",
-        "eslint-import-resolver-typescript": "^4",
-        "eslint-plugin-import-x": "^4",
-        "eslint-plugin-n": "^17",
-        "jiti": "^2",
-        "npm-run-all2": "^8",
-        "prettier": "^3",
-        "typescript": "^6.0",
-        "typescript-eslint": "^8"
+        "@eslint/compat": "^2.0.5",
+        "@eslint/js": "^10.0.1",
+        "@types/node": "^22.19.17",
+        "eslint": "^10.2.1",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-import-resolver-typescript": "^4.4.4",
+        "eslint-plugin-import-x": "^4.16.2",
+        "eslint-plugin-n": "^17.24.0",
+        "jiti": "^2.6.1",
+        "npm-run-all2": "^8.0.4",
+        "prettier": "^3.8.3",
+        "typescript": "^6.0.3",
+        "typescript-eslint": "^8.59.1"
       },
       "engines": {
         "node": ">=22.22"

--- a/package.json
+++ b/package.json
@@ -17,19 +17,19 @@
     "@commitlint/types": "^20.5.0"
   },
   "devDependencies": {
-    "@eslint/compat": "^2",
-    "@eslint/js": "^10",
-    "@types/node": "^22",
-    "eslint": "^10",
-    "eslint-config-prettier": "^10",
-    "eslint-import-resolver-typescript": "^4",
-    "eslint-plugin-import-x": "^4",
-    "eslint-plugin-n": "^17",
-    "jiti": "^2",
-    "npm-run-all2": "^8",
-    "prettier": "^3",
-    "typescript": "^6.0",
-    "typescript-eslint": "^8"
+    "@eslint/compat": "^2.0.5",
+    "@eslint/js": "^10.0.1",
+    "@types/node": "^22.19.17",
+    "eslint": "^10.2.1",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-import-resolver-typescript": "^4.4.4",
+    "eslint-plugin-import-x": "^4.16.2",
+    "eslint-plugin-n": "^17.24.0",
+    "jiti": "^2.6.1",
+    "npm-run-all2": "^8.0.4",
+    "prettier": "^3.8.3",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.59.1"
   },
   "engines": {
     "node": ">=22.22"


### PR DESCRIPTION
メジャーバージョンのみの曖昧な指定(`^2`、`^10`など)から、`package-lock.json`で実際に解決されているバージョン番号に変更しました。
実際の解決バージョンには影響しませんが、どのバージョンが基準になっているかが明確になります。
