### PR TITLE
feat: issue参照のアクションを`close`と`ref`のみに制限

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -2,6 +2,29 @@ import type { RulesConfig, UserConfig } from "@commitlint/types";
 import { RuleConfigSeverity } from "@commitlint/types";
 import { plugin as userPlugin, type RulesConfig as UserRulesConfig } from "./src/@commitlint/rules/index";
 
+/**
+ * issue参照キーワード。
+ * 特にcommitlintの標準データではrefは含まれていないので明示的に追加する必要があります。
+ */
+const allowedActions = ["close", "ref"] as const;
+
+/**
+ * issue参照キーワード。
+ * 認識して拒否するために最終的に許可しない語句もここに含める必要があります。
+ */
+const rejectedActions = [
+  "closed",
+  "closes",
+  "fix",
+  "fixed",
+  "fixes",
+  "references",
+  "refs",
+  "resolve",
+  "resolved",
+  "resolves",
+] as const;
+
 const rules: Partial<RulesConfig & UserRulesConfig> = {
   // ヘッダの幅は72文字まで。Git公式推奨の50文字は厳しすぎるので緩和。
   "header-max-length": [RuleConfigSeverity.Error, "always", 72],
@@ -17,31 +40,17 @@ const rules: Partial<RulesConfig & UserRulesConfig> = {
   "subject-case": [RuleConfigSeverity.Disabled],
 
   // issue参照のアクションキーワードは小文字単数の`close`と`ref`のみ許可。
-  "references-action-enum": [RuleConfigSeverity.Error, "always", ["close", "ref"]],
+  "references-action-enum": [RuleConfigSeverity.Error, "always", allowedActions],
 };
 
 const Configuration: UserConfig = {
   extends: ["@commitlint/config-conventional"],
-  // パーサがissue参照として抽出する語彙を拡張します。
-  // ここに含めない語句は参照として認識されないため`references-action-enum`で検査できません。
-  // 正しく拒否するために許可しない語句もここに含める必要があります。
-  // 大文字始まりはパーサがcase-insensitive(gi)で照合するためここに含める必要はありません。
   parserPreset: {
     parserOpts: {
-      referenceActions: [
-        "close",
-        "closed",
-        "closes",
-        "fix",
-        "fixed",
-        "fixes",
-        "ref",
-        "references",
-        "refs",
-        "resolve",
-        "resolved",
-        "resolves",
-      ],
+      // パーサがissue参照キーワードとして抽出する語彙を拡張します。
+      // ここに含めない語句は参照として認識されないため`references-action-enum`で検査できません。
+      // 大文字始まりはパーサがcase-insensitive(gi)で照合するため別途追加する必要はありません。
+      referenceActions: [...allowedActions, ...rejectedActions],
     },
   },
   rules,

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -15,10 +15,34 @@ const rules: Partial<RulesConfig & UserRulesConfig> = {
 
   // 関数などの識別子などを直接コミットメッセージのタイトルに書きたいのでcase識別は無効にします。
   "subject-case": [RuleConfigSeverity.Disabled],
+
+  // issue参照のアクションキーワードは小文字単数の`close`と`ref`のみ許可。
+  "references-action-enum": [RuleConfigSeverity.Error, "always", ["close", "ref"]],
 };
 
 const Configuration: UserConfig = {
   extends: ["@commitlint/config-conventional"],
+  // パーサがissue参照として抽出する語彙を拡張します。
+  // ここに含めない語句は参照として認識されないため`references-action-enum`で検査できません。
+  // 大文字始まりはパーサがcase-insensitive(gi)で照合するためここに含める必要はありません。
+  parserPreset: {
+    parserOpts: {
+      referenceActions: [
+        "close",
+        "closed",
+        "closes",
+        "fix",
+        "fixed",
+        "fixes",
+        "ref",
+        "references",
+        "refs",
+        "resolve",
+        "resolved",
+        "resolves",
+      ],
+    },
+  },
   rules,
   plugins: [userPlugin],
 };

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -24,6 +24,7 @@ const Configuration: UserConfig = {
   extends: ["@commitlint/config-conventional"],
   // パーサがissue参照として抽出する語彙を拡張します。
   // ここに含めない語句は参照として認識されないため`references-action-enum`で検査できません。
+  // 正しく拒否するために許可しない語句もここに含める必要があります。
   // 大文字始まりはパーサがcase-insensitive(gi)で照合するためここに含める必要はありません。
   parserPreset: {
     parserOpts: {

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -3,14 +3,15 @@ import { RuleConfigSeverity } from "@commitlint/types";
 import { plugin as userPlugin, type RulesConfig as UserRulesConfig } from "./src/@commitlint/rules/index";
 
 /**
- * issue参照キーワード。
- * 特にcommitlintの標準データではrefは含まれていないので明示的に追加する必要があります。
+ * コミットメッセージで許可するissue参照キーワード。
+ * 特にcommitlintの標準データでは`"ref"`は含まれていないので明示的に追加する必要があります。
  */
 const allowedActions = ["close", "ref"] as const;
 
 /**
- * issue参照キーワード。
- * 認識して拒否するために最終的に許可しない語句もここに含める必要があります。
+ * 明示的に拒否するためにパーサへ認識させるissue参照キーワード。
+ * `referenceActions`に登録されない語句はそもそも参照として抽出されず、
+ * ルール側で違反検出できないため列挙します。
  */
 const rejectedActions = [
   "closed",

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -3,17 +3,17 @@ import { RuleConfigSeverity } from "@commitlint/types";
 import { plugin as userPlugin, type RulesConfig as UserRulesConfig } from "./src/@commitlint/rules/index";
 
 const rules: Partial<RulesConfig & UserRulesConfig> = {
-  // 日本語なども含めた可読文字で終わることを求める。
-  "subject-alnum-stop": [RuleConfigSeverity.Error, "never"],
-
-  // 件名の長さはGit公式推奨の50文字は厳しすぎるのである程度緩和します。
+  // ヘッダの幅は72文字まで。Git公式推奨の50文字は厳しすぎるので緩和。
   "header-max-length": [RuleConfigSeverity.Error, "always", 72],
-
-  // 本文の1行幅はGit公式推奨の72文字は現代のターミナルを考えると厳しすぎるので100文字まで。
+  // ボディの1行幅は100文字まで。Git公式推奨の72文字は現代のターミナルの幅では合理的ではないです。
   "body-max-line-length": [RuleConfigSeverity.Error, "always", 100],
+  // フッタの1行幅は100文字まで。Git公式推奨の72文字は現代のターミナルの幅では合理的ではないです。
   "footer-max-line-length": [RuleConfigSeverity.Error, "always", 100],
 
-  // 関数などの識別子などを直接コミットメッセージのタイトルに書きたいので無効にする。
+  // タイトルは日本語を含めたUnicode可読文字で終わることを求めます。
+  "subject-alnum-stop": [RuleConfigSeverity.Error, "never"],
+
+  // 関数などの識別子などを直接コミットメッセージのタイトルに書きたいのでcase識別は無効にします。
   "subject-case": [RuleConfigSeverity.Disabled],
 };
 

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,7 @@
             fileset = lib.fileset.unions [
               ./src
               ./script
+              ./test
               ./.editorconfig
               ./.gitignore
               ./commit-msg
@@ -169,6 +170,7 @@
             lint-eslint = mkNpmCheck "lint-eslint" "lint:eslint";
             lint-prettier = mkNpmCheck "lint-prettier" "lint:prettier";
             lint-tsc = mkNpmCheck "lint-tsc" "lint:tsc";
+            test = mkNpmCheck "test" "test";
           };
 
           packages = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "git-hooks",
       "dependencies": {
         "@commitlint/cli": "^20.5.3",
         "@commitlint/config-conventional": "^20.5.3",
@@ -15,6 +14,7 @@
         "@eslint/compat": "^2.0.5",
         "@eslint/js": "^10.0.1",
         "@types/node": "^22.19.17",
+        "conventional-commits-parser": "^6.4.0",
         "eslint": "^10.2.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.4",
@@ -24,7 +24,8 @@
         "npm-run-all2": "^8.0.4",
         "prettier": "^3.8.3",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.59.1"
+        "typescript-eslint": "^8.59.1",
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": ">=22.22"
@@ -315,21 +316,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.7.1.tgz",
-      "integrity": "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
-      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -338,9 +339,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -549,6 +550,13 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -562,10 +570,303 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@package-json/types": {
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/@package-json/types/-/types-0.0.12.tgz",
       "integrity": "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
       "license": "MIT"
     },
@@ -596,6 +897,13 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -606,6 +914,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -1136,6 +1462,119 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1211,6 +1650,16 @@
       "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -1241,6 +1690,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/cliui": {
@@ -1320,9 +1779,9 @@
       }
     },
     "node_modules/conventional-commits-parser": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.3.0.tgz",
-      "integrity": "sha512-RfOq/Cqy9xV9bOA8N+ZH6DlrDR+5S3Mi0B5kACEjESpE+AviIpAptx9a9cFpWCCvgRtWT+0BbUw+e1BZfts9jg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
       "license": "MIT",
       "dependencies": {
         "@simple-libs/stream-utils": "^1.2.0",
@@ -1334,6 +1793,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
@@ -1418,6 +1884,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dot-prop": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
@@ -1467,6 +1943,13 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-toolkit": {
       "version": "1.46.1",
@@ -1858,6 +2341,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1866,6 +2359,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1972,6 +2475,21 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -2270,6 +2788,267 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -2290,6 +3069,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/memorystream": {
@@ -2344,6 +3133,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
@@ -2443,6 +3251,17 @@
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2544,6 +3363,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2574,6 +3400,35 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -2673,6 +3528,40 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -2721,6 +3610,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/stable-hash-x": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
@@ -2730,6 +3636,20 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -2771,6 +3691,13 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
@@ -2781,20 +3708,30 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -2942,6 +3879,174 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2956,6 +4061,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "run-p lint:*",
     "lint:eslint": "eslint .",
     "lint:prettier": "prettier --check .",
-    "lint:tsc": "tsc --noEmit"
+    "lint:tsc": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@commitlint/cli": "^20.5.3",
@@ -20,6 +21,7 @@
     "@eslint/compat": "^2.0.5",
     "@eslint/js": "^10.0.1",
     "@types/node": "^22.19.17",
+    "conventional-commits-parser": "^6.4.0",
     "eslint": "^10.2.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",
@@ -29,7 +31,8 @@
     "npm-run-all2": "^8.0.4",
     "prettier": "^3.8.3",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.59.1"
+    "typescript-eslint": "^8.59.1",
+    "vitest": "^4.1.5"
   },
   "engines": {
     "node": ">=22.22"

--- a/src/@commitlint/rules/index.ts
+++ b/src/@commitlint/rules/index.ts
@@ -1,12 +1,15 @@
 import { type RuleConfig, RuleConfigQuality, type Plugin } from "@commitlint/types";
+import { referencesActionEnum } from "./references-action-enum";
 import { subjectAlnumStop } from "./subject-alnum-stop";
 
-export const plugin: Plugin = {
+export const plugin = {
   rules: {
+    "references-action-enum": referencesActionEnum,
     "subject-alnum-stop": subjectAlnumStop,
   },
-};
+} as const satisfies Plugin;
 
 export interface RulesConfig<V = RuleConfigQuality.User> {
+  "references-action-enum": RuleConfig<V, readonly string[] | undefined>;
   "subject-alnum-stop": RuleConfig<V, RegExp | undefined>;
 }

--- a/src/@commitlint/rules/references-action-enum.ts
+++ b/src/@commitlint/rules/references-action-enum.ts
@@ -21,11 +21,16 @@ export const referencesActionEnum: SyncRule<readonly string[]> = (parsed, when, 
   }
 
   const violations = references.filter((reference) => reference.action != null && !value.includes(reference.action));
-  const negated = when === "never";
   const hasViolation = 0 < violations.length;
+  const violationsActions = violations.map((reference) => reference.action).join(", ");
+
+  const negated = when === "never";
+  const mustOrMustNot = negated ? "must not" : "must";
+
+  const expectValues = value.join(", ");
 
   return [
     negated ? hasViolation : !hasViolation,
-    message(["references action", negated ? "must not" : "must", `be one of [${value.join(", ")}]`]),
+    message([`references action ${violationsActions}`, mustOrMustNot, `be one of [${expectValues}]`]),
   ];
 };

--- a/src/@commitlint/rules/references-action-enum.ts
+++ b/src/@commitlint/rules/references-action-enum.ts
@@ -7,6 +7,10 @@ import type { SyncRule } from "@commitlint/types";
  * `action`が`null`(キーワード無しの裸の`#83`等)はスキップします。
  */
 export const referencesActionEnum: SyncRule<readonly string[]> = (parsed, when, value) => {
+  if (when == null && when !== "always" && when !== "never") {
+    throw new Error("Invalid rule configuration: when must be 'always' or 'never'");
+  }
+
   if (value == null || value.length === 0) {
     throw new Error("Invalid rule configuration: value must be a non-empty array");
   }

--- a/src/@commitlint/rules/references-action-enum.ts
+++ b/src/@commitlint/rules/references-action-enum.ts
@@ -10,7 +10,7 @@ import type { SyncRule } from "@commitlint/types";
  * `when="never"`: `value`に含まれるアクションを禁止し、それ以外を許可する。
  */
 export const referencesActionEnum: SyncRule<readonly string[]> = (parsed, when, value) => {
-  if (when !== "always" && when !== "never") {
+  if (when == null || (when !== "always" && when !== "never")) {
     throw new Error("references-action-enum: Invalid rule configuration: when must be 'always' or 'never'");
   }
 

--- a/src/@commitlint/rules/references-action-enum.ts
+++ b/src/@commitlint/rules/references-action-enum.ts
@@ -8,11 +8,11 @@ import type { SyncRule } from "@commitlint/types";
  */
 export const referencesActionEnum: SyncRule<readonly string[]> = (parsed, when, value) => {
   if (when == null && when !== "always" && when !== "never") {
-    throw new Error("Invalid rule configuration: when must be 'always' or 'never'");
+    throw new Error("references-action-enum: Invalid rule configuration: when must be 'always' or 'never'");
   }
 
   if (value == null || value.length === 0) {
-    throw new Error("Invalid rule configuration: value must be a non-empty array");
+    throw new Error("references-action-enum: Invalid rule configuration: value must be a non-empty array");
   }
 
   const references = parsed.references;

--- a/src/@commitlint/rules/references-action-enum.ts
+++ b/src/@commitlint/rules/references-action-enum.ts
@@ -11,12 +11,12 @@ export const referencesActionEnum: SyncRule<readonly string[]> = (parsed, when, 
     throw new Error("references-action-enum: Invalid rule configuration: when must be 'always' or 'never'");
   }
 
-  if (value == null || value.length === 0) {
+  if (!Array.isArray(value) || value.length === 0) {
     throw new Error("references-action-enum: Invalid rule configuration: value must be a non-empty array");
   }
 
   const references = parsed.references;
-  if (references == null || references.length === 0) {
+  if (!Array.isArray(references) || references.length === 0) {
     return [true];
   }
 

--- a/src/@commitlint/rules/references-action-enum.ts
+++ b/src/@commitlint/rules/references-action-enum.ts
@@ -37,6 +37,6 @@ export const referencesActionEnum: SyncRule<readonly string[]> = (parsed, when, 
 
   return [
     !hasViolation,
-    message([`references action ${violationsActions}`, mustOrMustNot, `be one of [${ruleValues}]`]),
+    message([`references action [${violationsActions}]`, mustOrMustNot, `be one of [${ruleValues}]`]),
   ];
 };

--- a/src/@commitlint/rules/references-action-enum.ts
+++ b/src/@commitlint/rules/references-action-enum.ts
@@ -1,0 +1,27 @@
+import message from "@commitlint/message";
+import type { SyncRule } from "@commitlint/types";
+
+/**
+ * issue参照に使えるアクションキーワードを限定します。
+ * `parsed.references[].action`が許可リストに完全一致するかをケース区別ありで検査します。
+ * `action`が`null`(キーワード無しの裸の`#83`等)はスキップします。
+ */
+export const referencesActionEnum: SyncRule<readonly string[]> = (parsed, when, value) => {
+  if (value == null || value.length === 0) {
+    throw new Error("Invalid rule configuration: value must be a non-empty array");
+  }
+
+  const references = parsed.references;
+  if (references == null || references.length === 0) {
+    return [true];
+  }
+
+  const violations = references.filter((reference) => reference.action != null && !value.includes(reference.action));
+  const negated = when === "never";
+  const hasViolation = 0 < violations.length;
+
+  return [
+    negated ? hasViolation : !hasViolation,
+    message(["references action", negated ? "must not" : "must", `be one of [${value.join(", ")}]`]),
+  ];
+};

--- a/src/@commitlint/rules/references-action-enum.ts
+++ b/src/@commitlint/rules/references-action-enum.ts
@@ -3,8 +3,11 @@ import type { SyncRule } from "@commitlint/types";
 
 /**
  * issue参照に使えるアクションキーワードを限定します。
- * `parsed.references[].action`が許可リストに完全一致するかをケース区別ありで検査します。
+ * `parsed.references[].action`をリストによりケース区別ありで検査します。
  * `action`が`null`(キーワード無しの裸の`#83`等)はスキップします。
+ *
+ * `when="always"`: `value`に含まれるアクションのみ許可し、それ以外を違反とする。
+ * `when="never"`: `value`に含まれるアクションを禁止し、それ以外を許可する。
  */
 export const referencesActionEnum: SyncRule<readonly string[]> = (parsed, when, value) => {
   if (when !== "always" && when !== "never") {

--- a/src/@commitlint/rules/references-action-enum.ts
+++ b/src/@commitlint/rules/references-action-enum.ts
@@ -7,7 +7,7 @@ import type { SyncRule } from "@commitlint/types";
  * `action`が`null`(キーワード無しの裸の`#83`等)はスキップします。
  */
 export const referencesActionEnum: SyncRule<readonly string[]> = (parsed, when, value) => {
-  if (when == null && when !== "always" && when !== "never") {
+  if (when !== "always" && when !== "never") {
     throw new Error("references-action-enum: Invalid rule configuration: when must be 'always' or 'never'");
   }
 

--- a/src/@commitlint/rules/references-action-enum.ts
+++ b/src/@commitlint/rules/references-action-enum.ts
@@ -20,17 +20,20 @@ export const referencesActionEnum: SyncRule<readonly string[]> = (parsed, when, 
     return [true];
   }
 
-  const violations = references.filter((reference) => reference.action != null && !value.includes(reference.action));
-  const hasViolation = 0 < violations.length;
-  const violationsActions = violations.map((reference) => reference.action).join(", ");
-
   const negated = when === "never";
   const mustOrMustNot = negated ? "must not" : "must";
 
-  const expectValues = value.join(", ");
+  const violations = references.filter(
+    (reference) =>
+      reference.action != null && (negated ? value.includes(reference.action) : !value.includes(reference.action)),
+  );
+  const hasViolation = 0 < violations.length;
+  const violationsActions = violations.map((reference) => reference.action).join(", ");
+
+  const ruleValues = value.join(", ");
 
   return [
     negated ? hasViolation : !hasViolation,
-    message([`references action ${violationsActions}`, mustOrMustNot, `be one of [${expectValues}]`]),
+    message([`references action ${violationsActions}`, mustOrMustNot, `be one of [${ruleValues}]`]),
   ];
 };

--- a/src/@commitlint/rules/references-action-enum.ts
+++ b/src/@commitlint/rules/references-action-enum.ts
@@ -33,7 +33,7 @@ export const referencesActionEnum: SyncRule<readonly string[]> = (parsed, when, 
   const ruleValues = value.join(", ");
 
   return [
-    negated ? hasViolation : !hasViolation,
+    !hasViolation,
     message([`references action ${violationsActions}`, mustOrMustNot, `be one of [${ruleValues}]`]),
   ];
 };

--- a/src/@commitlint/rules/subject-alnum-stop.ts
+++ b/src/@commitlint/rules/subject-alnum-stop.ts
@@ -7,11 +7,7 @@ import type { SyncRule } from "@commitlint/types";
  * 句読点など記号は無しがデフォルト。
  * インラインコード記法を許可するため特別にバッククオートだけは許可する。
  */
-export const subjectAlnumStop: SyncRule<RegExp | undefined> = (
-  parsed,
-  when = "always",
-  value = /[^\p{Letter}\p{Number}`]/u,
-) => {
+export const subjectAlnumStop: SyncRule<RegExp> = (parsed, when = "always", value = /[^\p{Letter}\p{Number}`]/u) => {
   const header = parsed.header;
   if (header == null) {
     return [true];

--- a/test/@commitlint/rules/references-action-enum.test.ts
+++ b/test/@commitlint/rules/references-action-enum.test.ts
@@ -1,0 +1,131 @@
+import type { Commit, CommitBase, CommitReference } from "conventional-commits-parser";
+import { createCommitObject } from "conventional-commits-parser";
+import { describe, expect, it } from "vitest";
+import { referencesActionEnum } from "../../../src/@commitlint/rules/references-action-enum";
+
+function buildReference(overrides: Partial<CommitReference> = {}): CommitReference {
+  return {
+    raw: "#1",
+    action: null,
+    owner: null,
+    repository: null,
+    issue: "1",
+    prefix: "#",
+    ...overrides,
+  };
+}
+
+/**
+ * `Commit`は`CommitBase & CommitMeta`の交差型でindex signatureを持つため、リテラルを`Partial<Commit>`に直接渡すと型エラーになる。
+ * `Object.assign`で`createCommitObject()`の戻り値に`Partial<CommitBase>`をマージすればキャスト無しで`Commit`値を構築できる。
+ */
+function buildCommit(references: CommitReference[]): Commit {
+  const overrides: Partial<CommitBase> = { header: "feat: x", references };
+  return Object.assign(createCommitObject(), overrides);
+}
+
+describe("referencesActionEnum", () => {
+  it("references配列が空ならpassします。", () => {
+    const [valid] = referencesActionEnum(buildCommit([]), "always", ["close", "ref"]);
+    expect(valid).toBe(true);
+  });
+
+  it("actionがcloseならpassします。", () => {
+    const [valid] = referencesActionEnum(buildCommit([buildReference({ action: "close" })]), "always", [
+      "close",
+      "ref",
+    ]);
+    expect(valid).toBe(true);
+  });
+
+  it("actionがrefならpassします。", () => {
+    const [valid] = referencesActionEnum(buildCommit([buildReference({ action: "ref" })]), "always", ["close", "ref"]);
+    expect(valid).toBe(true);
+  });
+
+  it("大文字始まりのCloseはケース区別ありで拒否されます。", () => {
+    const [valid, message] = referencesActionEnum(buildCommit([buildReference({ action: "Close" })]), "always", [
+      "close",
+      "ref",
+    ]);
+    expect(valid).toBe(false);
+    expect(message).toBe("references action Close must be one of [close, ref]");
+  });
+
+  it("複数形のClosesは拒否されます。", () => {
+    const [valid] = referencesActionEnum(buildCommit([buildReference({ action: "Closes" })]), "always", [
+      "close",
+      "ref",
+    ]);
+    expect(valid).toBe(false);
+  });
+
+  it("許可リストに含まれず拒否されます。", () => {
+    const [valid] = referencesActionEnum(buildCommit([buildReference({ action: "fix" })]), "always", ["close", "ref"]);
+    expect(valid).toBe(false);
+  });
+
+  it("refsは複数形なので拒否されます。", () => {
+    const [valid] = referencesActionEnum(buildCommit([buildReference({ action: "refs" })]), "always", ["close", "ref"]);
+    expect(valid).toBe(false);
+  });
+
+  it("actionがnullの裸の参照はスキップされてpassします。", () => {
+    const [valid] = referencesActionEnum(buildCommit([buildReference({ action: null })]), "always", ["close", "ref"]);
+    expect(valid).toBe(true);
+  });
+
+  it("複数の参照のうち1つでも無効ならfailし、メッセージには違反actionが列挙されます。", () => {
+    const [valid, message] = referencesActionEnum(
+      buildCommit([
+        buildReference({ action: "close" }),
+        buildReference({ action: "Fixes" }),
+        buildReference({ action: "refs" }),
+      ]),
+      "always",
+      ["close", "ref"],
+    );
+    expect(valid).toBe(false);
+    expect(message).toBe("references action Fixes, refs must be one of [close, ref]");
+  });
+
+  it("when=neverでは許可リストに含まれるactionが違反になります。", () => {
+    const [valid, message] = referencesActionEnum(buildCommit([buildReference({ action: "close" })]), "never", [
+      "close",
+      "ref",
+    ]);
+    expect(valid).toBe(false);
+    expect(message).toBe("references action close must not be one of [close, ref]");
+  });
+
+  it("when=neverで許可リスト外のactionだけならpassします。", () => {
+    const [valid] = referencesActionEnum(buildCommit([buildReference({ action: "Closes" })]), "never", [
+      "close",
+      "ref",
+    ]);
+    expect(valid).toBe(true);
+  });
+
+  it("valueを差し替えると別のactionも許可できます。", () => {
+    const [valid] = referencesActionEnum(buildCommit([buildReference({ action: "fix" })]), "always", ["fix"]);
+    expect(valid).toBe(true);
+  });
+
+  it("空のvalueを渡すと例外になります。", () => {
+    expect(() => referencesActionEnum(buildCommit([]), "always", [])).toThrow(
+      "references-action-enum: Invalid rule configuration: value must be a non-empty array",
+    );
+  });
+
+  it("valueが未指定のときも例外になります。", () => {
+    expect(() => referencesActionEnum(buildCommit([]), "always", undefined)).toThrow(
+      "references-action-enum: Invalid rule configuration: value must be a non-empty array",
+    );
+  });
+
+  it("whenが不正な値だと例外になります。", () => {
+    expect(() => referencesActionEnum(buildCommit([]), undefined, ["close", "ref"])).toThrow(
+      "references-action-enum: Invalid rule configuration: when must be 'always' or 'never'",
+    );
+  });
+});

--- a/test/@commitlint/rules/references-action-enum.test.ts
+++ b/test/@commitlint/rules/references-action-enum.test.ts
@@ -49,7 +49,7 @@ describe("referencesActionEnum", () => {
       "ref",
     ]);
     expect(valid).toBe(false);
-    expect(message).toBe("references action Close must be one of [close, ref]");
+    expect(message).toBe("references action [Close] must be one of [close, ref]");
   });
 
   it("複数形のClosesは拒否されます。", () => {
@@ -86,7 +86,7 @@ describe("referencesActionEnum", () => {
       ["close", "ref"],
     );
     expect(valid).toBe(false);
-    expect(message).toBe("references action Fixes, refs must be one of [close, ref]");
+    expect(message).toBe("references action [Fixes, refs] must be one of [close, ref]");
   });
 
   it("when=neverでは許可リストに含まれるactionが違反になります。", () => {
@@ -95,7 +95,7 @@ describe("referencesActionEnum", () => {
       "ref",
     ]);
     expect(valid).toBe(false);
-    expect(message).toBe("references action close must not be one of [close, ref]");
+    expect(message).toBe("references action [close] must not be one of [close, ref]");
   });
 
   it("when=neverで許可リスト外のactionだけならpassします。", () => {

--- a/test/@commitlint/rules/subject-alnum-stop.test.ts
+++ b/test/@commitlint/rules/subject-alnum-stop.test.ts
@@ -1,0 +1,74 @@
+import { createCommitObject, type Commit } from "conventional-commits-parser";
+import { describe, expect, it } from "vitest";
+import { subjectAlnumStop } from "../../../src/@commitlint/rules/subject-alnum-stop";
+
+function buildCommit(header: string | null): Commit {
+  return createCommitObject({ header });
+}
+
+describe("subjectAlnumStop", () => {
+  it("headerがnullならpassします。", () => {
+    const [valid] = subjectAlnumStop(buildCommit(null), "never");
+    expect(valid).toBe(true);
+  });
+
+  it("コロンで終わるheaderはpassします。", () => {
+    const [valid] = subjectAlnumStop(buildCommit("WIP:"), "never");
+    expect(valid).toBe(true);
+  });
+
+  it("英字で終わるheaderはwhen=neverでpassします。", () => {
+    const [valid] = subjectAlnumStop(buildCommit("feat: add foo"), "never");
+    expect(valid).toBe(true);
+  });
+
+  it("数字で終わるheaderはwhen=neverでpassします。", () => {
+    const [valid] = subjectAlnumStop(buildCommit("feat: bump to v2"), "never");
+    expect(valid).toBe(true);
+  });
+
+  it("日本語の漢字で終わるheaderはwhen=neverでpassします。", () => {
+    const [valid] = subjectAlnumStop(buildCommit("feat: 機能を追加"), "never");
+    expect(valid).toBe(true);
+  });
+
+  it("バッククオートで終わるheaderはwhen=neverでpassします。", () => {
+    const [valid] = subjectAlnumStop(buildCommit("feat: rename `foo`"), "never");
+    expect(valid).toBe(true);
+  });
+
+  it("ピリオドで終わるheaderはwhen=neverでfailします。", () => {
+    const [valid, message] = subjectAlnumStop(buildCommit("feat: add foo."), "never");
+    expect(valid).toBe(false);
+    expect(message).toBe("subject may not end with alnum stop");
+  });
+
+  it("日本語の句点で終わるheaderはwhen=neverでfailします。", () => {
+    const [valid] = subjectAlnumStop(buildCommit("feat: 機能を追加。"), "never");
+    expect(valid).toBe(false);
+  });
+
+  it("読点で終わるheaderはwhen=neverでfailします。", () => {
+    const [valid] = subjectAlnumStop(buildCommit("feat: 追加、"), "never");
+    expect(valid).toBe(false);
+  });
+
+  it("when=alwaysでは句読点で終わることが要求されます。", () => {
+    const [valid] = subjectAlnumStop(buildCommit("feat: add foo."), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("when=alwaysで英字終わりはfailします。", () => {
+    const [valid, message] = subjectAlnumStop(buildCommit("feat: add foo"), "always");
+    expect(valid).toBe(false);
+    expect(message).toBe("subject must end with alnum stop");
+  });
+
+  it("カスタム正規表現でセミコロンのみ判定対象にできます。", () => {
+    const onlySemicolon = /;/u;
+    const [validSemicolon] = subjectAlnumStop(buildCommit("feat: foo;"), "never", onlySemicolon);
+    expect(validSemicolon).toBe(false);
+    const [validPeriod] = subjectAlnumStop(buildCommit("feat: foo."), "never", onlySemicolon);
+    expect(validPeriod).toBe(true);
+  });
+});


### PR DESCRIPTION
issueへのリンク文字列としては小文字単数形の`close`と`ref`のみを受け付け、
`Closes`や`fix`、`refs`といった他のバリエーションは大文字始まりや複数形を含めて拒否します。
表記を統一してコミットメッセージの一貫性を高めるためです。

commitlintのパーサが抽出する`parsed.references[].action`を許可リストとケース区別ありで完全一致比較する独自ルールを追加しました。
キーワード無しの裸の`#83`形式は対象外としてスキップするので、本文中に散文として書く分には影響しません。

`conventional-commits-parser`のデフォルトには`ref`系の語彙が含まれていないため、
パーサ設定側にも`ref`、`refs`、`references`を追加して参照として抽出されるようにしています。
パーサが認識しない語句は文字列のままになりルール側で拒否できないためです。

close #83
