### PR TITLE
feat: コミットメッセージbodyの唐突な改行を抑制するルールを追加

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -40,6 +40,10 @@ const rules: Partial<RulesConfig & UserRulesConfig> = {
   // 関数などの識別子などを直接コミットメッセージのタイトルに書きたいのでcase識別は無効にします。
   "subject-case": [RuleConfigSeverity.Disabled],
 
+  // bodyの各行は句読点で終わり、句読点があれば改行することを求めます。
+  // 唐突な改行や句読点での改行漏れによる長過ぎる行を抑制します。
+  "body-line-break-punctuation": [RuleConfigSeverity.Error, "always"],
+
   // issue参照のアクションキーワードは小文字単数の`close`と`ref`のみ許可。
   "references-action-enum": [RuleConfigSeverity.Error, "always", allowedActions],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
         "@commitlint/cli": "^20.5.3",
         "@commitlint/config-conventional": "^20.5.3",
         "@commitlint/message": "^20.4.3",
-        "@commitlint/types": "^20.5.0"
+        "@commitlint/types": "^20.5.0",
+        "fp-ts": "^2.16.11",
+        "parser-ts": "^0.7.0"
       },
       "devDependencies": {
         "@eslint/compat": "^2.0.5",
@@ -2476,6 +2478,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fp-ts": {
+      "version": "2.16.11",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.11.tgz",
+      "integrity": "sha512-LaI+KaX2NFkfn1ZGHoKCmcfv7yrZsC3b8NtWsTVQeHkq4F27vI5igUuO53sxqDEa2gNQMHFPmpojDw/1zmUK7w==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3341,6 +3349,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parser-ts": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/parser-ts/-/parser-ts-0.7.0.tgz",
+      "integrity": "sha512-YBJYgQ6j2DiKryKkYUrw0a7WiUb2DGnanffFZNz5cRTaoTncSxjKCio6ocEBSAa26jFXr0XSNjaYXUrL61BISA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0"
+      },
+      "peerDependencies": {
+        "fp-ts": "^2.14.0"
       }
     },
     "node_modules/path-exists": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "@commitlint/cli": "^20.5.3",
     "@commitlint/config-conventional": "^20.5.3",
     "@commitlint/message": "^20.4.3",
-    "@commitlint/types": "^20.5.0"
+    "@commitlint/types": "^20.5.0",
+    "fp-ts": "^2.16.11",
+    "parser-ts": "^0.7.0"
   },
   "devDependencies": {
     "@eslint/compat": "^2.0.5",

--- a/src/@commitlint/rules/body-line-break-punctuation.ts
+++ b/src/@commitlint/rules/body-line-break-punctuation.ts
@@ -5,7 +5,6 @@ import { pipe } from "fp-ts/function";
 import * as P from "parser-ts/Parser";
 import { stream, type Stream } from "parser-ts/Stream";
 import * as C from "parser-ts/char";
-import * as S from "parser-ts/string";
 
 type Char = C.Char;
 
@@ -29,14 +28,39 @@ const isComma = (c: Char): boolean => commaChars.includes(c);
 const defaultTerminator = /[\p{P}`]/u;
 
 /** Markdownのリスト項目を判定する。インデントされたネストリストにも対応する。 */
-const listPattern = /^\s*([-*+]|\d+\.)\s/u;
+const listPattern = /^\s*([-*+]|\d+[.)])\s/u;
 
 /** Markdownの引用ブロックを判定する。引用部分は検査対象外とする。 */
 const quotePattern = /^\s*>/u;
 
-/** 検査対象外の行(空行・リスト項目・引用ブロック)を判定する。 */
+/** ATX見出し: `#`から`######`までの後にスペースまたは行末。 */
+const headingPattern = /^\s{0,3}#{1,6}(?:\s|$)/u;
+
+/** 水平線: `-`,`*`,`_` のいずれか同一文字が3回以上。 */
+const horizontalRulePattern = /^\s{0,3}([-*_])\s*(?:\1\s*){2,}$/u;
+
+/**
+ * setext見出しの下線。`=`もしくは`-`が並ぶ単独行で、前行を見出しに昇格させる。
+ * `---`は水平線パターンとも重なるが、いずれにせよ下線行自体は対象外なので問題ない。
+ */
+const setextUnderlinePattern = /^\s{0,3}(?:=+|-+)\s*$/u;
+
+/**
+ * 検査対象外の単独行(空行・リスト項目・引用ブロック・見出し・水平線・setext下線)を判定する。
+ *
+ * Markdownのバリエーションを完全網羅する意図はなく、
+ * コミットメッセージで遭遇しがちな代表的な構文に絞って対象外化する。
+ * setext見出しの段落行は単独行では判定できず、文法レベルで`setextHeadingBlock`がペアを認識する。
+ */
 function isExemptLine(line: string): boolean {
-  return line === "" || listPattern.test(line) || quotePattern.test(line);
+  return (
+    line === "" ||
+    listPattern.test(line) ||
+    quotePattern.test(line) ||
+    headingPattern.test(line) ||
+    horizontalRulePattern.test(line) ||
+    setextUnderlinePattern.test(line)
+  );
 }
 
 /** 与えられた終端文字の正規表現を、行末アンカー付きの正規表現に変換する。 */
@@ -44,16 +68,7 @@ function anchorAtEnd(terminator: RegExp): RegExp {
   return new RegExp(`(?:${terminator.source})$`, "u");
 }
 
-// ---- body 全体のパーサ ---------------------------------------------------
-//
-// body         := block*
-// block        := codeBlock | normalLine
-// codeBlock    := fenceLine anyLine* (fenceLine | EOF)
-// normalLine   := anyLine
-// anyLine      := <any non-newline char>* (newline | EOF)
-// fenceLine    := "```" anyLine
-//
-// codeBlock 内の行はすべて検査対象外として扱い、normalLine のみが行文字列を吐き出す。
+// ---- 共通の補助パーサ ---------------------------------------------------
 
 /** 行末(改行 or 入力終端)。 */
 const lineEnd: P.Parser<Char, void> = P.either(
@@ -67,58 +82,7 @@ const lineEnd: P.Parser<Char, void> = P.either(
 /** 1行(改行を含めて消費し、改行を除いた文字列を返す)。 */
 const anyLine: P.Parser<Char, string> = pipe(C.many(C.notChar("\n")), P.apFirst(lineEnd));
 
-/** 開始フェンス行。`"```"`から始まる行を1行として消費する。 */
-const fenceLine: P.Parser<Char, string> = pipe(
-  S.string("```"),
-  P.chain((prefix) =>
-    pipe(
-      anyLine,
-      P.map((rest) => prefix + rest),
-    ),
-  ),
-);
-
-/** コードブロックの終端(閉じフェンス、または入力終端)。 */
-const fenceCloseOrEof: P.Parser<Char, void> = P.either(
-  pipe(
-    fenceLine,
-    P.map<string, void>(() => undefined),
-  ),
-  () => P.eof<Char>(),
-);
-
-/** コードブロック1個。中身は検査対象外なので、空配列を返す。 */
-const codeBlock: P.Parser<Char, readonly string[]> = pipe(
-  fenceLine,
-  P.chain(() =>
-    pipe(
-      P.manyTill(anyLine, fenceCloseOrEof),
-      P.map((): readonly string[] => []),
-    ),
-  ),
-);
-
-/** 通常の1行。検査対象としてその行文字列を返す。 */
-const normalLine: P.Parser<Char, readonly string[]> = pipe(
-  anyLine,
-  P.map((line): readonly string[] => [line]),
-);
-
-/**
- * `many`が空消費で無限ループに陥らないよう、入力終端では失敗させるブロックパーサ。
- */
-const block: P.Parser<Char, readonly string[]> = pipe(
-  P.lookAhead(P.item<Char>()),
-  P.chain(() => P.either(codeBlock, () => normalLine)),
-);
-
-/** body全体を行配列に変換するパーサ。検査対象になる行のみを残す。 */
-const bodyToLines: P.Parser<Char, readonly string[]> = pipe(
-  P.many(block),
-  P.map((blocks) => blocks.flat()),
-);
-
-// ---- 1行の中間句読点の検査 ----------------------------------------------
+// ---- 1行内の中間句読点判定パーサ ---------------------------------------
 //
 // 行を1ストリームとみなして、最後の文字を残しつつ前方の文字を「中間として安全な文字」として消費する。
 // 安全とは「句点ではなく、かつ位置が`commaPrefixThreshold`未満であるか読点でない」こと。
@@ -183,8 +147,6 @@ function hasNoMidLinePunctuation(line: string): boolean {
   return isRight(result);
 }
 
-// ---- ルール本体 ----------------------------------------------------------
-
 /**
  * 個別の行が違反であるかを判定する。
  *
@@ -198,6 +160,147 @@ function isLineViolation(line: string, anchoredTerminator: RegExp, negated: bool
   return !endsWithTerminator || !hasNoMidLinePunctuation(line);
 }
 
+// ---- body 全体の文法 ----------------------------------------------------
+//
+// body              := block*
+// block             := codeBlockBlock | setextHeadingBlock | exemptLineBlock | contentLineBlock
+// codeBlockBlock    := fenceLine anyLine* (fenceClose(opener) | EOF)
+// setextHeadingBlock:= paragraphLine setextUnderline
+// exemptLineBlock   := <isExemptLineにマッチする1行>
+// contentLineBlock  := anyLine
+// paragraphLine     := <isExemptLineにマッチしない1行>
+// setextUnderline   := <setextUnderlinePatternにマッチする1行>
+// fenceLine         := <fenceMatcherにマッチする1行>
+//
+// alternativeで上から順に試し、各ブロックは違反行のリストを返す。
+// codeBlock・setextHeading・exemptLineは検査対象外なので空配列を返し、
+// contentLineBlockのみが行末や中間句読点を検査して違反を抽出する。
+
+type FenceKind = "backtick" | "tilde";
+
+interface FenceInfo {
+  readonly kind: FenceKind;
+  readonly length: number;
+}
+
+const fenceMatcher = /^\s{0,3}(`{3,}|~{3,})/u;
+
+/** 各ブロックパーサが返す違反行のリスト。 */
+type BlockResult = readonly string[];
+
+/**
+ * 1行先読みしてフェンス行か判定し、フェンスであればその種類と長さを返しつつ実際に1行消費する。
+ *
+ * `P.lookAhead`が消費を巻き戻すので、フェンスでない場合はカーソルが進まないまま失敗できる。
+ */
+const fenceLine: P.Parser<Char, FenceInfo> = pipe(
+  P.lookAhead(anyLine),
+  P.chain((line) => {
+    const matched = fenceMatcher.exec(line);
+    if (matched == null) {
+      return P.fail<Char, FenceInfo>();
+    }
+    const marker = matched[1] ?? "";
+    const info: FenceInfo = {
+      kind: marker.startsWith("`") ? "backtick" : "tilde",
+      length: marker.length,
+    };
+    return pipe(
+      anyLine,
+      P.map((): FenceInfo => info),
+    );
+  }),
+);
+
+/**
+ * コードブロックの終端(同じ種類かつ開始以上の長さを持つ閉じフェンス、または入力終端)。
+ *
+ * CommonMarkに合わせて、4個で開いたフェンスを3個で閉じることはできない。
+ */
+const fenceCloseOrEof = (opener: FenceInfo): P.Parser<Char, void> =>
+  P.either(
+    pipe(
+      fenceLine,
+      P.filter((closer: FenceInfo) => closer.kind === opener.kind && closer.length >= opener.length),
+      P.map<FenceInfo, void>(() => undefined),
+    ),
+    () => P.eof<Char>(),
+  );
+
+/** コードブロック1個。中身は検査対象外なので、空配列を返す。 */
+const codeBlockBlock: P.Parser<Char, BlockResult> = pipe(
+  fenceLine,
+  P.chain((opener) =>
+    pipe(
+      P.manyTill(anyLine, fenceCloseOrEof(opener)),
+      P.map((): BlockResult => []),
+    ),
+  ),
+);
+
+/**
+ * setext見出しの2行ペア。
+ *
+ * 1行目が「単独行としては検査対象になる行」(=isExemptLineにマッチしない)、
+ * 2行目が`setextUnderlinePattern`にマッチする場合のみマッチする。
+ * いずれかの条件が崩れた場合は`P.either`の効果により入力位置がロールバックされる。
+ */
+const setextHeadingBlock: P.Parser<Char, BlockResult> = pipe(
+  P.lookAhead(anyLine),
+  P.filter((line: string) => !isExemptLine(line)),
+  P.chain(() => anyLine),
+  P.chain(() =>
+    pipe(
+      P.lookAhead(anyLine),
+      P.filter((line: string) => setextUnderlinePattern.test(line)),
+      P.chain(() => anyLine),
+      P.map((): BlockResult => []),
+    ),
+  ),
+);
+
+/** 単独行で対象外と判定できる1行を消費するブロック。 */
+const exemptLineBlock: P.Parser<Char, BlockResult> = pipe(
+  P.lookAhead(anyLine),
+  P.filter((line: string) => isExemptLine(line)),
+  P.chain(() => anyLine),
+  P.map((): BlockResult => []),
+);
+
+/** 検査対象になる通常の行。違反であればその行を、そうでなければ空配列を返す。 */
+const contentLineBlock = (anchoredTerminator: RegExp, negated: boolean): P.Parser<Char, BlockResult> =>
+  pipe(
+    anyLine,
+    P.map((line): BlockResult => (isLineViolation(line, anchoredTerminator, negated) ? [line] : [])),
+  );
+
+/**
+ * 1ブロック分のパーサ。
+ *
+ * 入力終端では`P.lookAhead(P.item)`が失敗するので、`P.many`の無限ループを防げる。
+ */
+const block = (anchoredTerminator: RegExp, negated: boolean): P.Parser<Char, BlockResult> =>
+  pipe(
+    P.lookAhead(P.item<Char>()),
+    P.chain(() =>
+      pipe(
+        codeBlockBlock,
+        P.alt(() => setextHeadingBlock),
+        P.alt(() => exemptLineBlock),
+        P.alt(() => contentLineBlock(anchoredTerminator, negated)),
+      ),
+    ),
+  );
+
+/** body全体を消費して違反行のリストを返すパーサ。 */
+const bodyParser = (anchoredTerminator: RegExp, negated: boolean): P.Parser<Char, BlockResult> =>
+  pipe(
+    P.many(block(anchoredTerminator, negated)),
+    P.map((blocks) => blocks.flat()),
+  );
+
+// ---- ルール本体 ----------------------------------------------------------
+
 /**
  * コミットメッセージ`body`の唐突な改行を抑制するルール。
  *
@@ -206,7 +309,8 @@ function isLineViolation(line: string, anchoredTerminator: RegExp, negated: bool
  * - 行の途中に句点(`.`/`。`/`．`)が無い
  * - 行の途中の読点(`,`/`，`/`、`)は前置文字数が閾値以下のときのみ許容する
  *
- * 空行・リスト項目(`-`/`*`/`+`/番号付き)・コードフェンス内・引用ブロックは対象外。
+ * 空行・リスト項目(`-`/`*`/`+`/番号付き)・コードフェンス内・引用ブロック・
+ * ATX見出し・水平線・setext見出し(段落行+下線のペア)は対象外。
  *
  * `when="never"`: 行末が`value`の終端文字で終わる行を違反とする。
  */
@@ -219,10 +323,8 @@ export const bodyLineBreakPunctuation: SyncRule<RegExp> = (parsed, when = "alway
   const negated = when === "never";
   const anchoredTerminator = anchorAtEnd(value);
 
-  const parsedBody = bodyToLines(stream(Array.from(body)));
-  const lines: readonly string[] = isRight(parsedBody) ? parsedBody.right.value : [];
-
-  const violations = lines.filter((line) => !isExemptLine(line) && isLineViolation(line, anchoredTerminator, negated));
+  const result = bodyParser(anchoredTerminator, negated)(stream(Array.from(body)));
+  const violations: readonly string[] = isRight(result) ? result.right.value : [];
 
   if (violations.length === 0) {
     return [true];

--- a/src/@commitlint/rules/body-line-break-punctuation.ts
+++ b/src/@commitlint/rules/body-line-break-punctuation.ts
@@ -1,0 +1,135 @@
+import message from "@commitlint/message";
+import type { SyncRule } from "@commitlint/types";
+
+/**
+ * 読点を改行強制対象から外す前置文字数の閾値。
+ * 数文字程度の接続詞(`また、`等)は途中の読点でも改行を求めない。
+ */
+const commaPrefixThreshold = 5 as const;
+
+/**
+ * 行末以外に出現する句点を検出する。改行を伴わない句点は違反扱い。
+ */
+const midLinePeriodPattern = /[.。．](?!$)/u;
+
+/**
+ * 行末以外で、かつ前置文字数が`commaPrefixThreshold`以上の読点を検出する。
+ */
+const midLineCommaPattern = new RegExp(`(?<=.{${commaPrefixThreshold},})[,，、](?!$)`, "u");
+
+/**
+ * 行末として許容する終端文字のデフォルト集合。
+ * UnicodeのPunctuationプロパティをベースとし、
+ * 加えてインラインコード記法のためにバッククオートを許可する。
+ */
+const defaultTerminator = /[\p{P}`]/u;
+
+/**
+ * Markdownのリスト項目を判定する。インデントされたネストリストにも対応する。
+ */
+const listPattern = /^\s*([-*+]|\d+\.)\s/u;
+
+/**
+ * Markdownの引用ブロックを判定する。
+ * 引用部分はオリジナルの文章を保つ必要があるため検査対象外とする。
+ */
+const quotePattern = /^\s*>/u;
+
+/**
+ * 行とそれがコードフェンス領域(フェンス自身を含む)に属するかのフラグの組。
+ */
+type AnnotatedLine = readonly [line: string, inCodeBlock: boolean];
+
+/**
+ * 行配列を走査し、各行をコードフェンス領域フラグ付きの組に変換する。
+ * フェンス行自身も領域として扱い、後続処理で添字アクセス無しに行を識別できるようにする。
+ */
+interface ScanState {
+  readonly inBlock: boolean;
+  readonly annotated: readonly AnnotatedLine[];
+}
+
+function annotateCodeBlock(lines: readonly string[]): readonly AnnotatedLine[] {
+  const initial: ScanState = { inBlock: false, annotated: [] };
+  return lines.reduce<ScanState>((state, line) => {
+    const isFence = line.startsWith("```");
+    const entry: AnnotatedLine = [line, isFence || state.inBlock];
+    return {
+      inBlock: isFence ? !state.inBlock : state.inBlock,
+      annotated: [...state.annotated, entry],
+    };
+  }, initial).annotated;
+}
+
+/**
+ * 検査対象外の行(空行・リスト項目・引用ブロック)を判定する。
+ */
+function isExemptLine(line: string): boolean {
+  return line === "" || listPattern.test(line) || quotePattern.test(line);
+}
+
+/**
+ * 行内に句点や条件付きの読点が出現するかを正規表現マッチで判定する。
+ */
+function hasMidLinePunctuation(line: string): boolean {
+  return midLinePeriodPattern.test(line) || midLineCommaPattern.test(line);
+}
+
+/**
+ * 個別の行が違反であるかを判定する。
+ * `negated`が真のとき終端の有無のみで判定し、偽のときは中間句読点も併せて判定する。
+ */
+function isLineViolation(line: string, anchoredTerminator: RegExp, negated: boolean): boolean {
+  const endsWithTerminator = anchoredTerminator.test(line);
+  if (negated) {
+    return endsWithTerminator;
+  }
+  return !endsWithTerminator || hasMidLinePunctuation(line);
+}
+
+/**
+ * 与えられた終端文字の正規表現を、行末アンカー付きの正規表現に変換する。
+ * 行から最後の文字を取り出して`test`する逐次操作を回避し、
+ * 正規表現のマッチング機能のみで行末判定を完結させる。
+ */
+function anchorAtEnd(terminator: RegExp): RegExp {
+  return new RegExp(`(?:${terminator.source})$`, "u");
+}
+
+/**
+ * コミットメッセージ`body`の唐突な改行を抑制するルール。
+ *
+ * `when="always"`: 各行は次の双方を満たす必要がある。
+ * - 行末が`value`の終端文字で終わる
+ * - 行の途中に句点(`.`/`。`/`．`)が無い
+ * - 行の途中の読点(`,`/`，`/`、`)は前置文字数が閾値以下のときのみ許容する
+ *
+ * 空行・リスト項目(`-`/`*`/`+`/番号付き)・コードフェンス内・引用ブロックは対象外。
+ *
+ * `when="never"`: 行末が`value`の終端文字で終わる行を違反とする。
+ */
+export const bodyLineBreakPunctuation: SyncRule<RegExp> = (parsed, when = "always", value = defaultTerminator) => {
+  const body = parsed.body;
+  if (body == null || body === "") {
+    return [true];
+  }
+
+  const negated = when === "never";
+  const anchoredTerminator = anchorAtEnd(value);
+  const annotatedLines = annotateCodeBlock(body.split("\n"));
+
+  const violations = annotatedLines
+    .filter(([line, inCodeBlock]) => !inCodeBlock && !isExemptLine(line))
+    .map(([line]) => line)
+    .filter((line) => isLineViolation(line, anchoredTerminator, negated));
+
+  if (violations.length === 0) {
+    return [true];
+  }
+
+  const verb = negated ? "must not" : "must";
+  return [
+    false,
+    message([`body lines [${violations.join(" / ")}]`, verb, "end with punctuation and break after sentences"]),
+  ];
+};

--- a/src/@commitlint/rules/body-line-break-punctuation.ts
+++ b/src/@commitlint/rules/body-line-break-punctuation.ts
@@ -1,5 +1,13 @@
 import message from "@commitlint/message";
 import type { SyncRule } from "@commitlint/types";
+import { isRight } from "fp-ts/Either";
+import { pipe } from "fp-ts/function";
+import * as P from "parser-ts/Parser";
+import { stream, type Stream } from "parser-ts/Stream";
+import * as C from "parser-ts/char";
+import * as S from "parser-ts/string";
+
+type Char = C.Char;
 
 /**
  * 読点を改行強制対象から外す前置文字数の閾値。
@@ -7,15 +15,11 @@ import type { SyncRule } from "@commitlint/types";
  */
 const commaPrefixThreshold = 5 as const;
 
-/**
- * 行末以外に出現する句点を検出する。改行を伴わない句点は違反扱い。
- */
-const midLinePeriodPattern = /[.。．](?!$)/u;
+const periodChars = ".。．" as const;
+const commaChars = ",，、" as const;
 
-/**
- * 行末以外で、かつ前置文字数が`commaPrefixThreshold`以上の読点を検出する。
- */
-const midLineCommaPattern = new RegExp(`(?<=.{${commaPrefixThreshold},})[,，、](?!$)`, "u");
+const isPeriod = (c: Char): boolean => periodChars.includes(c);
+const isComma = (c: Char): boolean => commaChars.includes(c);
 
 /**
  * 行末として許容する終端文字のデフォルト集合。
@@ -24,59 +28,166 @@ const midLineCommaPattern = new RegExp(`(?<=.{${commaPrefixThreshold},})[,，、
  */
 const defaultTerminator = /[\p{P}`]/u;
 
-/**
- * Markdownのリスト項目を判定する。インデントされたネストリストにも対応する。
- */
+/** Markdownのリスト項目を判定する。インデントされたネストリストにも対応する。 */
 const listPattern = /^\s*([-*+]|\d+\.)\s/u;
 
-/**
- * Markdownの引用ブロックを判定する。
- * 引用部分はオリジナルの文章を保つ必要があるため検査対象外とする。
- */
+/** Markdownの引用ブロックを判定する。引用部分は検査対象外とする。 */
 const quotePattern = /^\s*>/u;
 
-/**
- * 行とそれがコードフェンス領域(フェンス自身を含む)に属するかのフラグの組。
- */
-type AnnotatedLine = readonly [line: string, inCodeBlock: boolean];
-
-/**
- * 行配列を走査し、各行をコードフェンス領域フラグ付きの組に変換する。
- * フェンス行自身も領域として扱い、後続処理で添字アクセス無しに行を識別できるようにする。
- */
-interface ScanState {
-  readonly inBlock: boolean;
-  readonly annotated: readonly AnnotatedLine[];
-}
-
-function annotateCodeBlock(lines: readonly string[]): readonly AnnotatedLine[] {
-  const initial: ScanState = { inBlock: false, annotated: [] };
-  return lines.reduce<ScanState>((state, line) => {
-    const isFence = line.startsWith("```");
-    const entry: AnnotatedLine = [line, isFence || state.inBlock];
-    return {
-      inBlock: isFence ? !state.inBlock : state.inBlock,
-      annotated: [...state.annotated, entry],
-    };
-  }, initial).annotated;
-}
-
-/**
- * 検査対象外の行(空行・リスト項目・引用ブロック)を判定する。
- */
+/** 検査対象外の行(空行・リスト項目・引用ブロック)を判定する。 */
 function isExemptLine(line: string): boolean {
   return line === "" || listPattern.test(line) || quotePattern.test(line);
 }
 
-/**
- * 行内に句点や条件付きの読点が出現するかを正規表現マッチで判定する。
- */
-function hasMidLinePunctuation(line: string): boolean {
-  return midLinePeriodPattern.test(line) || midLineCommaPattern.test(line);
+/** 与えられた終端文字の正規表現を、行末アンカー付きの正規表現に変換する。 */
+function anchorAtEnd(terminator: RegExp): RegExp {
+  return new RegExp(`(?:${terminator.source})$`, "u");
 }
+
+// ---- body 全体のパーサ ---------------------------------------------------
+//
+// body         := block*
+// block        := codeBlock | normalLine
+// codeBlock    := fenceLine anyLine* (fenceLine | EOF)
+// normalLine   := anyLine
+// anyLine      := <any non-newline char>* (newline | EOF)
+// fenceLine    := "```" anyLine
+//
+// codeBlock 内の行はすべて検査対象外として扱い、normalLine のみが行文字列を吐き出す。
+
+/** 行末(改行 or 入力終端)。 */
+const lineEnd: P.Parser<Char, void> = P.either(
+  pipe(
+    C.char("\n"),
+    P.map<Char, void>(() => undefined),
+  ),
+  () => P.eof<Char>(),
+);
+
+/** 1行(改行を含めて消費し、改行を除いた文字列を返す)。 */
+const anyLine: P.Parser<Char, string> = pipe(C.many(C.notChar("\n")), P.apFirst(lineEnd));
+
+/** 開始フェンス行。`"```"`から始まる行を1行として消費する。 */
+const fenceLine: P.Parser<Char, string> = pipe(
+  S.string("```"),
+  P.chain((prefix) =>
+    pipe(
+      anyLine,
+      P.map((rest) => prefix + rest),
+    ),
+  ),
+);
+
+/** コードブロックの終端(閉じフェンス、または入力終端)。 */
+const fenceCloseOrEof: P.Parser<Char, void> = P.either(
+  pipe(
+    fenceLine,
+    P.map<string, void>(() => undefined),
+  ),
+  () => P.eof<Char>(),
+);
+
+/** コードブロック1個。中身は検査対象外なので、空配列を返す。 */
+const codeBlock: P.Parser<Char, readonly string[]> = pipe(
+  fenceLine,
+  P.chain(() =>
+    pipe(
+      P.manyTill(anyLine, fenceCloseOrEof),
+      P.map((): readonly string[] => []),
+    ),
+  ),
+);
+
+/** 通常の1行。検査対象としてその行文字列を返す。 */
+const normalLine: P.Parser<Char, readonly string[]> = pipe(
+  anyLine,
+  P.map((line): readonly string[] => [line]),
+);
+
+/**
+ * `many`が空消費で無限ループに陥らないよう、入力終端では失敗させるブロックパーサ。
+ */
+const block: P.Parser<Char, readonly string[]> = pipe(
+  P.lookAhead(P.item<Char>()),
+  P.chain(() => P.either(codeBlock, () => normalLine)),
+);
+
+/** body全体を行配列に変換するパーサ。検査対象になる行のみを残す。 */
+const bodyToLines: P.Parser<Char, readonly string[]> = pipe(
+  P.many(block),
+  P.map((blocks) => blocks.flat()),
+);
+
+// ---- 1行の中間句読点の検査 ----------------------------------------------
+//
+// 行を1ストリームとみなして、最後の文字を残しつつ前方の文字を「中間として安全な文字」として消費する。
+// 安全とは「句点ではなく、かつ位置が`commaPrefixThreshold`未満であるか読点でない」こと。
+
+/** 残り2文字以上あることを先読みで確認する(消費はしない)。 */
+const hasNextChar: P.Parser<Char, void> = P.lookAhead(
+  pipe(
+    P.item<Char>(),
+    P.chain(() => P.item<Char>()),
+    P.map<Char, void>(() => undefined),
+  ),
+);
+
+/**
+ * 中間として安全な1文字を消費する。
+ *
+ * - 残り1文字以下のときは「最終文字」とみなしてここでは消費しない。
+ * - 句点であれば中間禁止なので失敗。
+ * - 読点で位置が`commaPrefixThreshold`以上なら中間禁止なので失敗。
+ */
+const midLineSafeChar: P.Parser<Char, Char> = pipe(
+  hasNextChar,
+  P.chain(() =>
+    pipe(
+      P.withStart(P.item<Char>()),
+      P.filter(([ch, start]: [Char, Stream<Char>]) => {
+        if (isPeriod(ch)) return false;
+        if (isComma(ch) && start.cursor >= commaPrefixThreshold) return false;
+        return true;
+      }),
+      P.map(([ch]) => ch),
+    ),
+  ),
+);
+
+/**
+ * 行を「中間禁止文字なし」として読み切るパーサ。
+ *
+ * 中間文字を可能な限り消費した後、最終1文字を任意の文字として消費する(空行は許容)。
+ */
+const noMidLinePunctuation: P.Parser<Char, void> = pipe(
+  P.many(midLineSafeChar),
+  P.chain(() =>
+    P.either(
+      pipe(
+        P.eof<Char>(),
+        P.map<void, void>(() => undefined),
+      ),
+      () =>
+        pipe(
+          P.item<Char>(),
+          P.chainFirst(() => P.eof<Char>()),
+          P.map<Char, void>(() => undefined),
+        ),
+    ),
+  ),
+);
+
+/** 行に中間句読点が無いかを判定する。 */
+function hasNoMidLinePunctuation(line: string): boolean {
+  const result = noMidLinePunctuation(stream(Array.from(line)));
+  return isRight(result);
+}
+
+// ---- ルール本体 ----------------------------------------------------------
 
 /**
  * 個別の行が違反であるかを判定する。
+ *
  * `negated`が真のとき終端の有無のみで判定し、偽のときは中間句読点も併せて判定する。
  */
 function isLineViolation(line: string, anchoredTerminator: RegExp, negated: boolean): boolean {
@@ -84,16 +195,7 @@ function isLineViolation(line: string, anchoredTerminator: RegExp, negated: bool
   if (negated) {
     return endsWithTerminator;
   }
-  return !endsWithTerminator || hasMidLinePunctuation(line);
-}
-
-/**
- * 与えられた終端文字の正規表現を、行末アンカー付きの正規表現に変換する。
- * 行から最後の文字を取り出して`test`する逐次操作を回避し、
- * 正規表現のマッチング機能のみで行末判定を完結させる。
- */
-function anchorAtEnd(terminator: RegExp): RegExp {
-  return new RegExp(`(?:${terminator.source})$`, "u");
+  return !endsWithTerminator || !hasNoMidLinePunctuation(line);
 }
 
 /**
@@ -116,12 +218,11 @@ export const bodyLineBreakPunctuation: SyncRule<RegExp> = (parsed, when = "alway
 
   const negated = when === "never";
   const anchoredTerminator = anchorAtEnd(value);
-  const annotatedLines = annotateCodeBlock(body.split("\n"));
 
-  const violations = annotatedLines
-    .filter(([line, inCodeBlock]) => !inCodeBlock && !isExemptLine(line))
-    .map(([line]) => line)
-    .filter((line) => isLineViolation(line, anchoredTerminator, negated));
+  const parsedBody = bodyToLines(stream(Array.from(body)));
+  const lines: readonly string[] = isRight(parsedBody) ? parsedBody.right.value : [];
+
+  const violations = lines.filter((line) => !isExemptLine(line) && isLineViolation(line, anchoredTerminator, negated));
 
   if (violations.length === 0) {
     return [true];

--- a/src/@commitlint/rules/body-line-break-punctuation.ts
+++ b/src/@commitlint/rules/body-line-break-punctuation.ts
@@ -4,9 +4,7 @@ import { isRight } from "fp-ts/Either";
 import { pipe } from "fp-ts/function";
 import * as P from "parser-ts/Parser";
 import { stream, type Stream } from "parser-ts/Stream";
-import * as C from "parser-ts/char";
-
-type Char = C.Char;
+import { type Char, default as C } from "parser-ts/char";
 
 /**
  * 読点を改行強制対象から外す前置文字数の閾値。

--- a/src/@commitlint/rules/body-line-break-punctuation.ts
+++ b/src/@commitlint/rules/body-line-break-punctuation.ts
@@ -10,7 +10,7 @@ import { type Char, default as C } from "parser-ts/char";
  * 読点を改行強制対象から外す前置文字数の閾値。
  * 数文字程度の接続詞(`また、`等)は途中の読点でも改行を求めない。
  */
-const commaPrefixThreshold = 5 as const;
+const commaPrefixThreshold = 6 as const;
 
 const periodChars = ".。．" as const;
 const commaChars = ",，、" as const;
@@ -305,7 +305,7 @@ const bodyParser = (anchoredTerminator: RegExp, negated: boolean): P.Parser<Char
  * `when="always"`: 各行は以下の条件を全て満たす必要がある。
  * - 行末が`value`の終端文字で終わる
  * - 行の途中に句点(`.`/`。`/`．`)が無い
- * - 行の途中の読点(`,`/`，`/`、`)は前置文字数が閾値以下のときのみ許容する
+ * - 行の途中の読点(`,`/`，`/`、`)は前置文字数が閾値未満のときのみ許容する
  *
  * 空行・リスト項目(`-`/`*`/`+`/番号付き)・コードフェンス内・引用ブロック・
  * ATX見出し・水平線・setext見出し(段落行+下線のペア)は対象外。

--- a/src/@commitlint/rules/body-line-break-punctuation.ts
+++ b/src/@commitlint/rules/body-line-break-punctuation.ts
@@ -324,7 +324,7 @@ export const bodyLineBreakPunctuation: SyncRule<RegExp> = (parsed, when = "alway
   const result = bodyParser(anchoredTerminator, negated)(stream(Array.from(body)));
 
   if (isLeft(result)) {
-    // ブロックを消費するはずなので`Left`にはならないはずなので想定外なので例外を投げます。
+    // `bodyParser`は`P.many(block(...))`で全入力を消費しきるため`Left`にはならないはずなので想定外として例外を投げる。
     throw new Error("Unexpected parse failure in bodyLineBreakPunctuation");
   }
 

--- a/src/@commitlint/rules/body-line-break-punctuation.ts
+++ b/src/@commitlint/rules/body-line-break-punctuation.ts
@@ -1,6 +1,6 @@
 import message from "@commitlint/message";
 import type { SyncRule } from "@commitlint/types";
-import { isRight } from "fp-ts/Either";
+import { isLeft, isRight } from "fp-ts/Either";
 import { pipe } from "fp-ts/function";
 import * as P from "parser-ts/Parser";
 import { stream, type Stream } from "parser-ts/Stream";
@@ -322,7 +322,13 @@ export const bodyLineBreakPunctuation: SyncRule<RegExp> = (parsed, when = "alway
   const anchoredTerminator = anchorAtEnd(value);
 
   const result = bodyParser(anchoredTerminator, negated)(stream(Array.from(body)));
-  const violations: readonly string[] = isRight(result) ? result.right.value : [];
+
+  if (isLeft(result)) {
+    // ブロックを消費するはずなので`Left`にはならないはずなので想定外なので例外を投げます。
+    throw new Error("Unexpected parse failure in bodyLineBreakPunctuation");
+  }
+
+  const violations: readonly string[] = result.right.value;
 
   if (violations.length === 0) {
     return [true];

--- a/src/@commitlint/rules/body-line-break-punctuation.ts
+++ b/src/@commitlint/rules/body-line-break-punctuation.ts
@@ -302,7 +302,7 @@ const bodyParser = (anchoredTerminator: RegExp, negated: boolean): P.Parser<Char
 /**
  * コミットメッセージ`body`の唐突な改行を抑制するルール。
  *
- * `when="always"`: 各行は次の双方を満たす必要がある。
+ * `when="always"`: 各行は以下の条件を全て満たす必要がある。
  * - 行末が`value`の終端文字で終わる
  * - 行の途中に句点(`.`/`。`/`．`)が無い
  * - 行の途中の読点(`,`/`，`/`、`)は前置文字数が閾値以下のときのみ許容する

--- a/src/@commitlint/rules/index.ts
+++ b/src/@commitlint/rules/index.ts
@@ -1,15 +1,18 @@
 import { type RuleConfig, RuleConfigQuality, type Plugin } from "@commitlint/types";
+import { bodyLineBreakPunctuation } from "./body-line-break-punctuation";
 import { referencesActionEnum } from "./references-action-enum";
 import { subjectAlnumStop } from "./subject-alnum-stop";
 
 export const plugin = {
   rules: {
+    "body-line-break-punctuation": bodyLineBreakPunctuation,
     "references-action-enum": referencesActionEnum,
     "subject-alnum-stop": subjectAlnumStop,
   },
 } as const satisfies Plugin;
 
 export interface RulesConfig<V = RuleConfigQuality.User> {
+  "body-line-break-punctuation": RuleConfig<V, RegExp | undefined>;
   "references-action-enum": RuleConfig<V, readonly string[] | undefined>;
   "subject-alnum-stop": RuleConfig<V, RegExp | undefined>;
 }

--- a/test/@commitlint/rules/body-line-break-punctuation.test.ts
+++ b/test/@commitlint/rules/body-line-break-punctuation.test.ts
@@ -240,6 +240,27 @@ second part.`;
     expect(msg).toContain("違反2の行");
   });
 
+  it("単一違反のalwaysメッセージは指定の構造を持ちます。", () => {
+    const [valid, msg] = bodyLineBreakPunctuation(buildCommit("句読点なしの一行"), "always");
+    expect(valid).toBe(false);
+    expect(msg).toBe("body lines [句読点なしの一行] must end with punctuation and break after sentences");
+  });
+
+  it("複数違反のalwaysメッセージは違反行を` / `で結合します。", () => {
+    const body = `違反1の行
+違反2の行
+句点で終わる。`;
+    const [valid, msg] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(false);
+    expect(msg).toBe("body lines [違反1の行 / 違反2の行] must end with punctuation and break after sentences");
+  });
+
+  it("neverメッセージは`must not`を含む指定の構造を持ちます。", () => {
+    const [valid, msg] = bodyLineBreakPunctuation(buildCommit("ends with period."), "never");
+    expect(valid).toBe(false);
+    expect(msg).toBe("body lines [ends with period.] must not end with punctuation and break after sentences");
+  });
+
   it("カスタム正規表現で句点のみ許可するとカンマ終わりはfailします。", () => {
     const onlyPeriod = /[.。]/u;
     const body = `ends with comma,

--- a/test/@commitlint/rules/body-line-break-punctuation.test.ts
+++ b/test/@commitlint/rules/body-line-break-punctuation.test.ts
@@ -1,0 +1,352 @@
+import { createCommitObject, type Commit } from "conventional-commits-parser";
+import { describe, expect, it } from "vitest";
+import { bodyLineBreakPunctuation } from "../../../src/@commitlint/rules/body-line-break-punctuation";
+
+function buildCommit(body: string | null): Commit {
+  return createCommitObject({ header: "feat: x", body });
+}
+
+describe("bodyLineBreakPunctuation", () => {
+  it("bodyがnullならpassします。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit(null), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("bodyが空文字ならpassします。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit(""), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("単一行で句点で終わるbodyはpassします。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit("単一行で句点で終わる。"), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("単一行で句読点なしのbodyはfailします。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit("単一行で句読点なし"), "always");
+    expect(valid).toBe(false);
+  });
+
+  it("全ての行が句点で終わる日本語のbodyはpassします。", () => {
+    const body = `1行目です。
+2行目です。
+3行目です。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("全ての行がピリオドで終わる英文のbodyはpassします。", () => {
+    const body = `First line.
+Second line.
+Third line.`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("読点で終わって続く行もpassします。", () => {
+    const body = `読点で終わって、
+次の行に続く。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("カンマで終わって続く行もpassします。", () => {
+    const body = `ends with comma,
+next line.`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("疑問符で終わる行はpassします。", () => {
+    const body = `本当ですか？
+本当です。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("感嘆符で終わる行はpassします。", () => {
+    const body = `Wow!
+それは凄い。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("最終行も句読点で終わることが要求されます。", () => {
+    const body = `前の行は句点で終わる。
+最後の行は句読点なし`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(false);
+  });
+
+  it("句読点なしで唐突に改行する日本語はfailします。", () => {
+    const body = `句読点のない
+唐突な改行は禁止。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(false);
+  });
+
+  it("句読点なしで改行する英文はfailします。", () => {
+    const body = `no punctuation here
+but still continues.`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(false);
+  });
+
+  it("途中の行が句読点で終わらないとfailします。", () => {
+    const body = `1行目は句点。
+2行目に句読点なし
+3行目に続く。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(false);
+  });
+
+  it("空行はそれ自身は対象外です。", () => {
+    const body = `段落1の終わり。
+
+段落2の始まり。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("段落最後の行が句読点なしならfailします(空行の前の行)。", () => {
+    const body = `段落1は句点なしで終わる
+
+段落2は句点で終わる。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(false);
+  });
+
+  it("ハイフンで始まるリスト項目は対象外です。", () => {
+    const body = `リスト:
+
+- 項目1
+- 項目2
+- 項目3`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("アスタリスクで始まるリスト項目は対象外です。", () => {
+    const body = `リスト:
+
+* 項目1
+* 項目2
+* 項目3`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("プラス記号で始まるリスト項目は対象外です。", () => {
+    const body = `リスト:
+
++ 項目1
++ 項目2
++ 項目3`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("番号付きリスト項目は対象外です。", () => {
+    const body = `手順:
+
+1. 最初
+2. 次
+3. 最後`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("インデントされたリスト項目も対象外です。", () => {
+    const body = `ネスト:
+
+- 親項目
+  - 子項目1
+  - 子項目2`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("コードブロック内は対象外です。", () => {
+    const body = `コード例:
+
+\`\`\`
+function foo() {
+  return 42
+}
+\`\`\`
+
+以上です。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("言語指定付きのコードブロック内も対象外です。", () => {
+    const body = `コード例:
+
+\`\`\`typescript
+const x = 1
+const y = 2
+\`\`\`
+
+以上です。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("コードブロックの直前の行が句読点なしならfailします。", () => {
+    const body = `コード例
+
+\`\`\`
+const x = 1
+\`\`\`
+
+以上です。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(false);
+  });
+
+  it("コードブロックが閉じていないと内部扱いとなり後続も無視されます。", () => {
+    const body = `始まり:
+
+\`\`\`
+const x = 1
+const y = 2`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("コロンで終わる行はpassします。", () => {
+    const body = `次の通りです:
+
+- 項目`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("セミコロンで終わる行はpassします。", () => {
+    const body = `first part;
+second part.`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("複数違反はメッセージで全て列挙されます。", () => {
+    const body = `違反1の行
+違反2の行
+句点で終わる。`;
+    const [valid, msg] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(false);
+    expect(msg).toContain("違反1の行");
+    expect(msg).toContain("違反2の行");
+  });
+
+  it("カスタム正規表現で句点のみ許可するとカンマ終わりはfailします。", () => {
+    const onlyPeriod = /[.。]/u;
+    const body = `ends with comma,
+next line.`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always", onlyPeriod);
+    expect(valid).toBe(false);
+  });
+
+  it("when=neverでは句読点で終わる行が違反になります。", () => {
+    const body = `ends with period.
+next line.`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "never");
+    expect(valid).toBe(false);
+  });
+
+  it("when=neverで句読点なしの行はpassします。", () => {
+    const body = `no punctuation
+next line`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "never");
+    expect(valid).toBe(true);
+  });
+
+  it("句点が行の途中にあるとfailします。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit("1行目です。2行目です。"), "always");
+    expect(valid).toBe(false);
+  });
+
+  it("英文ピリオドが行の途中にあるとfailします。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit("First sentence. Second sentence."), "always");
+    expect(valid).toBe(false);
+  });
+
+  it("読点が行の途中で前置文字が短ければpassします。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit("また、続きを書きます。"), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("読点が行の途中で前置文字が長いとfailします。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit("とても長い前置きを書いた後で、続きを書きます。"), "always");
+    expect(valid).toBe(false);
+  });
+
+  it("英文カンマが行の途中で前置文字が短ければpassします。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit("Hi, world."), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("英文カンマが行の途中で前置文字が長いとfailします。", () => {
+    const [valid] = bodyLineBreakPunctuation(
+      buildCommit("This is a very long preamble, and the rest continues."),
+      "always",
+    );
+    expect(valid).toBe(false);
+  });
+
+  it("コロンが行の途中にあるのは許容されます。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit("key: value here."), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("セミコロンが行の途中にあるのは許容されます。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit("first; second; third."), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("疑問符が行の途中にあるのは許容されます。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit("Really? Yes indeed."), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("感嘆符が行の途中にあるのは許容されます。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit("Wow! Amazing thing!"), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("句点が行末ならば違反ではありません。", () => {
+    const body = `1文目です。
+2文目です。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("複数の句点が中間にある単一行はfailします。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit("1文目。2文目。3文目。"), "always");
+    expect(valid).toBe(false);
+  });
+
+  it("引用ブロックの中身は対象外です。", () => {
+    const body = `引用元の発言:
+
+> 唐突に改行してる
+> 句読点なしの文も含む
+> 文中に。句点もある
+
+以上です。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("インデントされた引用ブロックも対象外です。", () => {
+    const body = `引用:
+
+  > 引用文に句読点なし
+  > 続く
+
+末尾です。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+});

--- a/test/@commitlint/rules/body-line-break-punctuation.test.ts
+++ b/test/@commitlint/rules/body-line-break-punctuation.test.ts
@@ -349,4 +349,155 @@ next line`;
     const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
     expect(valid).toBe(true);
   });
+
+  it("ATX見出しは対象外です。", () => {
+    const body = `# 見出し
+
+本文の最後。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("複数レベルのATX見出しも対象外です。", () => {
+    const body = `# 見出し1
+
+## 見出し2
+
+### 見出し3
+
+本文。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("水平線(ハイフン)は対象外です。", () => {
+    const body = `区切り前。
+
+---
+
+区切り後。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("水平線(アスタリスク)は対象外です。", () => {
+    const body = `区切り前。
+
+***
+
+区切り後。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("水平線(アンダースコア)は対象外です。", () => {
+    const body = `区切り前。
+
+___
+
+区切り後。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("チルダのコードフェンスも対象外です。", () => {
+    const body = `コード:
+
+~~~
+const x = 1
+~~~
+
+以上です。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("インデントされたバッククオートフェンスも対象外です。", () => {
+    const body = `コード:
+
+  \`\`\`
+  const x = 1
+  \`\`\`
+
+以上です。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("4個以上のバッククオートフェンスも対象外です。", () => {
+    const body = `コード:
+
+\`\`\`\`
+\`\`\`
+内側に短いフェンス
+\`\`\`
+\`\`\`\`
+
+以上です。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("チルダフェンス内のバッククオートはフェンスを閉じません。", () => {
+    const body = `~~~
+\`\`\`
+中身です
+\`\`\`
+~~~
+
+本文の終わり。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("番号付きリストの`1)`形式も対象外です。", () => {
+    const body = `手順:
+
+1) 最初
+2) 次
+3) 最後`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("setext見出しの`=`下線(h1)は前行とペアで対象外です。", () => {
+    const body = `見出し
+======
+
+本文の最後。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("setext見出しの`-`下線(h2)は前行とペアで対象外です。", () => {
+    const body = `見出し
+------
+
+本文の最後。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("複数のsetext見出しが連続しても各ペアで対象外です。", () => {
+    const body = `見出し1
+======
+
+本文1。
+
+見出し2
+------
+
+本文2。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("body冒頭のsetext見出しも対象外です。", () => {
+    const body = `冒頭の見出し
+============
+
+本文。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
 });

--- a/test/@commitlint/rules/body-line-break-punctuation.test.ts
+++ b/test/@commitlint/rules/body-line-break-punctuation.test.ts
@@ -480,6 +480,45 @@ const x = 1
     expect(valid).toBe(true);
   });
 
+  it("5個のバッククオートフェンスは3個では閉じられず以降が全てコードブロック扱いになります。", () => {
+    const body = `コード:
+
+\`\`\`\`\`
+const x = 1
+\`\`\`
+内側に句読点なしの行があっても検出されない
+\`\`\`\`\`
+
+末尾です。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("チルダフェンスをバッククオートで閉じようとしても閉じず内部の違反は検出されません。", () => {
+    const body = `~~~
+const x = 1
+\`\`\`
+ここは句読点なしでも違反として検出されない
+\`\`\`
+~~~
+
+本文の終わり。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("4スペース以上インデントしたバッククオートはフェンスとして認識されず内側が検査対象になります。", () => {
+    const body = `コード:
+
+    \`\`\`
+    const x = 1
+    \`\`\`
+
+末尾。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(false);
+  });
+
   it("番号付きリストの`1)`形式も対象外です。", () => {
     const body = `手順:
 

--- a/test/@commitlint/rules/body-line-break-punctuation.test.ts
+++ b/test/@commitlint/rules/body-line-break-punctuation.test.ts
@@ -272,6 +272,25 @@ next line`;
     expect(valid).toBe(false);
   });
 
+  it("全角句点で終わる行はpassします。", () => {
+    const body = `1行目です．
+2行目です．`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("全角句点が行の途中にあるとfailします。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit("1行目です．2行目です．"), "always");
+    expect(valid).toBe(false);
+  });
+
+  it("全角カンマで終わる行はpassします。", () => {
+    const body = `読点で終わる，
+次の行に続く．`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
   it("読点が行の途中で前置文字が短ければpassします。", () => {
     const [valid] = bodyLineBreakPunctuation(buildCommit("また、続きを書きます。"), "always");
     expect(valid).toBe(true);
@@ -564,6 +583,32 @@ const x = 1
   it("body冒頭のsetext見出しも対象外です。", () => {
     const body = `冒頭の見出し
 ============
+
+本文。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("段落行と下線の間に空行があるとsetext見出しとして扱われず段落行が違反として検査されます。", () => {
+    const body = `見出し候補
+
+======
+
+本文。`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(false);
+  });
+
+  it("段落行がリスト項目の場合setext見出しとして扱われずsetextHeadingBlockがロールバックします。", () => {
+    const body = `- 項目
+======
+句読点なしの行`;
+    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");
+    expect(valid).toBe(false);
+  });
+
+  it("孤立した下線行のみが出現してもexemptLineBlockで対象外として扱われます。", () => {
+    const body = `======
 
 本文。`;
     const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always");

--- a/test/@commitlint/rules/body-line-break-punctuation.test.ts
+++ b/test/@commitlint/rules/body-line-break-punctuation.test.ts
@@ -282,6 +282,16 @@ next line`;
     expect(valid).toBe(false);
   });
 
+  it("読点の前置文字が閾値未満(5文字)ならpassします。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit("あいうえお、続きます。"), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("読点の前置文字が閾値ちょうど(6文字)ならfailします。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit("あいうえおか、続きます。"), "always");
+    expect(valid).toBe(false);
+  });
+
   it("英文カンマが行の途中で前置文字が短ければpassします。", () => {
     const [valid] = bodyLineBreakPunctuation(buildCommit("Hi, world."), "always");
     expect(valid).toBe(true);
@@ -292,6 +302,26 @@ next line`;
       buildCommit("This is a very long preamble, and the rest continues."),
       "always",
     );
+    expect(valid).toBe(false);
+  });
+
+  it("英文カンマの前置文字が閾値未満(5文字)ならpassします。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit("12345, rest of the line."), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("英文カンマの前置文字が閾値ちょうど(6文字)ならfailします。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit("123456, rest of the line."), "always");
+    expect(valid).toBe(false);
+  });
+
+  it("全角カンマの前置文字が閾値未満(5文字)ならpassします。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit("あいうえお，続きます。"), "always");
+    expect(valid).toBe(true);
+  });
+
+  it("全角カンマの前置文字が閾値ちょうど(6文字)ならfailします。", () => {
+    const [valid] = bodyLineBreakPunctuation(buildCommit("あいうえおか，続きます。"), "always");
     expect(valid).toBe(false);
   });
 


### PR DESCRIPTION
LLMがコミットメッセージのbodyを書くとき、
唐突に改行する英語圏の慣習が抜けないため、
プロンプトでの誘導ではなくルールで強制するための新ルールを追加します。

新ルール`body-line-break-punctuation`は、
行末がUnicode Punctuationプロパティもしくはバッククオートで終わることを要求し、
句点が行の途中に出現することを違反として抽出します。
読点は前置文字数が一定以上のときのみ違反として扱います。
例外として`また、`のような短い接続詞では改行を強制しません。

以下のMarkdown構文はひと通り検査対象外にしてあります。

- 空行
- リスト項目
- コードフェンス(バッククオート/チルダ、インデント許容)
- 引用ブロック
- ATX見出し
- setext見出し(段落行と下線のペア)
- 水平線

コミットメッセージのbodyで実際によく使う構文を、
唐突な改行ではない正当な記法として通すためです。

close #80