### PR TITLE
fix(body-line-break-punctuation): URLやMarkdownリンク記法を中間句読点判定の対象から除外

### DIFF
--- a/src/@commitlint/rules/body-line-break-punctuation/extract-markdown.ts
+++ b/src/@commitlint/rules/body-line-break-punctuation/extract-markdown.ts
@@ -10,26 +10,38 @@ import { gfm } from "micromark-extension-gfm";
 const fromMarkdownOptions: FromMarkdownOptions = { extensions: [gfm()], mdastExtensions: [gfmFromMarkdown()] };
 
 /**
- * `inlineCode`の中身は中間句読点判定の対象外なので、
- * 段落をテキスト化するときに無害な英字列に置換する。
+ * 中間句読点判定の対象外とする可視テキストを、無害な英字列で囲んでマスクする。
  * 外側のバッククオートはそのまま残し、行末terminatorとしての扱いを維持する。
+ * `inlineCode`、リンク、画像など原典のテキストをそのまま使う要素で共通利用する。
  */
-function inlineCodeToText(value: string): string {
+function maskAsInlineCode(value: string): string {
   return `\`${"x".repeat(value.length)}\``;
 }
 
 /**
  * `paragraph`配下の`PhrasingContent`を文字列として再構築する。
- * `inlineCode`はマスクし、`break`は改行に、入れ子(`emphasis`等)は子要素を再帰的に展開する。
+ * `inlineCode`、リンク(URLおよびリンクテキスト)、画像(altテキスト)はマスクする。
+ * `break`は改行に、入れ子(`emphasis`等)は子要素を再帰的に展開する。
+ *
+ * リンクをマスクするのは、URL自体は当然句読点を含み得るし、
+ * Markdownリンク記法`[title](url)`のtitleも原典のものを使うため句読点が入り得るためです。
+ * 拡張Markdownのオートリンク記法(`<URL>`)やGFM autolink-literalで認識される素のURLも、
+ * mdast上は`link`ノードとなるため同じ扱いになります。
  */
 function phrasingToText(node: PhrasingContent): string {
   switch (node.type) {
     case "text":
       return node.value;
     case "inlineCode":
-      return inlineCodeToText(node.value);
+      return maskAsInlineCode(node.value);
     case "break":
       return "\n";
+    case "link":
+    case "linkReference":
+      return maskAsInlineCode(node.children.map(phrasingToText).join(""));
+    case "image":
+    case "imageReference":
+      return maskAsInlineCode(node.alt ?? "");
     default:
       return "children" in node ? node.children.map(phrasingToText).join("") : "";
   }

--- a/test/@commitlint/rules/body-line-break-punctuation.test.ts
+++ b/test/@commitlint/rules/body-line-break-punctuation.test.ts
@@ -742,4 +742,87 @@ const x = 1
       expect(valid).toBe(true);
     });
   });
+
+  describe("URLや参照を許可する", () => {
+    it("issueへの番号参照(#123)のみの行は許可されます。", () => {
+      const [valid, msg] = bodyLineBreakPunctuation(buildCommit("close #123."), "always");
+      expect(msg).toBeUndefined();
+      expect(valid).toBe(true);
+    });
+
+    it("文中にissue番号参照(#123)があってもpassします。", () => {
+      const [valid, msg] = bodyLineBreakPunctuation(buildCommit("issue #123 を参照する。"), "always");
+      expect(msg).toBeUndefined();
+      expect(valid).toBe(true);
+    });
+
+    it("URLを単独で貼り付けてもpassします。", () => {
+      const [valid, msg] = bodyLineBreakPunctuation(
+        buildCommit("https://github.com/ncaq/git-hooks/issues/91"),
+        "always",
+      );
+      expect(msg).toBeUndefined();
+      expect(valid).toBe(true);
+    });
+
+    it("文中にURLを直接貼り付けてもpassします。", () => {
+      const [valid, msg] = bodyLineBreakPunctuation(
+        buildCommit("詳細は https://github.com/ncaq/git-hooks/issues/91 を参照。"),
+        "always",
+      );
+      expect(msg).toBeUndefined();
+      expect(valid).toBe(true);
+    });
+
+    it("拡張Markdownのオートリンク記法(<URL>)はpassします。", () => {
+      const [valid, msg] = bodyLineBreakPunctuation(buildCommit("<https://example.com/foo.html>"), "always");
+      expect(msg).toBeUndefined();
+      expect(valid).toBe(true);
+    });
+
+    it("文中にオートリンク記法(<URL>)があってもpassします。", () => {
+      const [valid, msg] = bodyLineBreakPunctuation(
+        buildCommit("詳細は<https://example.com/foo.html>を参照。"),
+        "always",
+      );
+      expect(msg).toBeUndefined();
+      expect(valid).toBe(true);
+    });
+
+    it("Markdownリンク記法のタイトルに句点が含まれていてもpassします。", () => {
+      const [valid, msg] = bodyLineBreakPunctuation(
+        buildCommit("[これはタイトル。です](https://example.com/)を参照。"),
+        "always",
+      );
+      expect(msg).toBeUndefined();
+      expect(valid).toBe(true);
+    });
+
+    it("Markdownリンク記法のタイトルにカンマが含まれていてもpassします。", () => {
+      const [valid, msg] = bodyLineBreakPunctuation(
+        buildCommit("[Hello, world](https://example.com/)を参照。"),
+        "always",
+      );
+      expect(msg).toBeUndefined();
+      expect(valid).toBe(true);
+    });
+
+    it("Markdownリンク記法でURL中にドットがあってもpassします。", () => {
+      const [valid, msg] = bodyLineBreakPunctuation(
+        buildCommit("[git-hooks](https://github.com/ncaq/git-hooks)を参照。"),
+        "always",
+      );
+      expect(msg).toBeUndefined();
+      expect(valid).toBe(true);
+    });
+
+    it("複数のリンクが文中にあってもpassします。", () => {
+      const [valid, msg] = bodyLineBreakPunctuation(
+        buildCommit("[a](https://example.com/a)と[b](https://example.com/b)を参照。"),
+        "always",
+      );
+      expect(msg).toBeUndefined();
+      expect(valid).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
issueの参照やURLの貼り付け、
拡張Markdownのオートリンク記法、
Markdownリンク記法によるリンク貼り付けが、
内部の句読点を中間句点として誤検出されて違反扱いされていました。

これまで`phrasingToText`は`inlineCode`のみマスクし、
`link`や`linkReference`はデフォルト分岐で子要素を再帰展開していました。
mdastではGFM autolink-literalで認識される素のURLや拡張Markdownのオートリンク記法(`<URL>`)も`link`ノードになるため、
URL中の`.`や`/`が中間句点として検出されてしまいます。
`[title](url)`形式のMarkdownリンク記法でも、
タイトルは原典のものをそのまま使うため句読点が入り得ます。

そこで`link`/`linkReference`/`image`/`imageReference`を、
`inlineCode`と同じくバッククオートで囲んで無害な英字列に置換するように変更しました。
外側のバッククオートが行末terminatorとしての役割を果たすため、
URL単独の行も自然にpassします。
共通化された意図を示すため、
`inlineCodeToText`を`maskAsInlineCode`に改名しています。

close #91
