### PR TITLE
refactor: フックスクリプトをhooksディレクトリに移動し構成を整理

### DIFF
--- a/commit-msg
+++ b/commit-msg
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -eu
-
-script_dir=$(dirname "$0")
-commit_editmsg_file="$(realpath "${1}")"
-npm --prefix "$script_dir" exec -- \
-  commitlint --config "$script_dir/commitlint.config.ts" --edit "$commit_editmsg_file"

--- a/flake.nix
+++ b/flake.nix
@@ -42,13 +42,16 @@
         let
           inherit (pkgs) nodejs;
 
+          npmFileset = lib.fileset.unions [
+            ./package.json
+            ./package-lock.json
+          ];
+
           npmRoot = lib.fileset.toSource {
             root = ./.;
-            fileset = lib.fileset.unions [
-              ./package.json
-              ./package-lock.json
-            ];
+            fileset = npmFileset;
           };
+
           nodeModules = pkgs.importNpmLock.buildNodeModules {
             inherit
               nodejs
@@ -56,21 +59,22 @@
               ;
           };
 
-          tsSrc = lib.fileset.toSource {
+          tsFileset = lib.fileset.unions [
+            npmFileset
+
+            ./src
+            ./test
+
+            ./.editorconfig
+            ./.gitignore
+            ./commitlint.config.ts
+            ./eslint.config.ts
+            ./tsconfig.json
+          ];
+
+          tsRoot = lib.fileset.toSource {
             root = ./.;
-            fileset = lib.fileset.unions [
-              ./src
-              ./script
-              ./test
-              ./.editorconfig
-              ./.gitignore
-              ./commit-msg
-              ./commitlint.config.ts
-              ./eslint.config.ts
-              ./package.json
-              ./post-merge
-              ./tsconfig.json
-            ];
+            fileset = tsFileset;
           };
 
           # npm run経由でスクリプト実行を簡単にするためのヘルパー。
@@ -81,7 +85,7 @@
                 nativeBuildInputs = [ nodejs ];
               }
               ''
-                cp -r ${tsSrc}/. .
+                cp -r ${tsRoot}/. .
                 ln -s ${nodeModules}/node_modules node_modules
                 npm run ${script}
                 touch $out
@@ -106,19 +110,22 @@
               mkdir -p $out/lib/git-hooks
 
               ln -s ${nodeModules}/node_modules $out/lib/git-hooks/node_modules
-              cp -r script $out/lib/git-hooks/
+
+              cp -r ${./hooks} $out/lib/git-hooks/hooks
+              cp -r ${./script} $out/lib/git-hooks/script
               cp -r src $out/lib/git-hooks/
-              cp commit-msg $out/lib/git-hooks/
+
               cp commitlint.config.ts $out/lib/git-hooks/
               cp package.json $out/lib/git-hooks/
-              cp post-merge $out/lib/git-hooks/
 
               runHook postInstall
             '';
 
             postFixup = ''
-              for hook in $out/lib/git-hooks/commit-msg $out/lib/git-hooks/post-merge $out/lib/git-hooks/script/delete-merged-branch; do
-                wrapProgram "$hook" --prefix PATH : ${
+              for exec in $out/lib/git-hooks/hooks/commit-msg \
+                          $out/lib/git-hooks/hooks/post-merge \
+                          $out/lib/git-hooks/script/delete-merged-branch; do
+                wrapProgram "$exec" --prefix PATH : ${
                   lib.makeBinPath (
                     with pkgs;
                     [

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(dirname "$0")"
+project_root="$(realpath "$script_dir/..")"
+
+commit_editmsg_file="$(realpath "${1}")"
+
+npm --prefix "$project_root" exec -- \
+  commitlint --config "$project_root/commitlint.config.ts" --edit "$commit_editmsg_file"

--- a/hooks/post-merge
+++ b/hooks/post-merge
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(dirname "$0")"
+project_root="$(realpath "$script_dir/..")"
+
+"$project_root"/script/delete-merged-branch

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -23,6 +23,6 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    programs.git.settings.core.hooksPath = "${cfg.package}/lib/git-hooks";
+    programs.git.settings.core.hooksPath = "${cfg.package}/lib/git-hooks/hooks";
   };
 }

--- a/post-merge
+++ b/post-merge
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-set -eu
-"$(dirname "$0")"/script/delete-merged-branch


### PR DESCRIPTION
- commit-msg, post-mergeフックをhooksディレクトリへ移動
- スクリプトのパス解決をプロジェクトルート基準に修正
- flake.nix, home-manager.nixを新構成に対応
