### PR TITLE
build(deps-dev): deprecatedな@eslint/compatからeslint/configに移行

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,8 +1,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { includeIgnoreFile } from "@eslint/compat";
 import { configs as eslintConfigs } from "@eslint/js";
-import { defineConfig } from "eslint/config";
+import { defineConfig, includeIgnoreFile } from "eslint/config";
 import eslintConfigPrettier from "eslint-config-prettier";
 import { createTypeScriptImportResolver } from "eslint-import-resolver-typescript";
 import { flatConfigs as importPluginConfig } from "eslint-plugin-import-x";
@@ -19,7 +18,10 @@ const gitignorePath: string = path.resolve(__dirname, ".gitignore");
 /** ESLintが使用する設定を定義。 */
 const config: ReturnType<typeof defineConfig> = defineConfig(
   // どのプロジェクトでも共通して適用するルール。
-  includeIgnoreFile(gitignorePath), // .gitignoreから無視するべきファイルを継承。
+  // `.gitignore`から無視するべきファイルを継承。
+  // `gitignoreResolution: true`でignoreファイル自身からの相対パスとして解決する、
+  // 本来のgitignore挙動にします。
+  includeIgnoreFile(gitignorePath, { gitignoreResolution: true }),
   eslintConfigPrettier, // prettierと競合しないようにします。
   importPluginConfig.recommended, // importの推奨プリセット。
   importPluginConfig.typescript, // importのTypeScript向け推奨プリセット。

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,12 +22,11 @@
       },
       "devDependencies": {
         "@effect/language-service": "^0.86.1",
-        "@eslint/compat": "^2.0.5",
         "@eslint/js": "^10.0.1",
         "@types/mdast": "^4.0.4",
         "@types/node": "^22.19.17",
         "conventional-commits-parser": "^6.4.0",
-        "eslint": "^10.3.0",
+        "eslint": "^10.4.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import-x": "^4.16.2",
@@ -527,27 +526,6 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
-    "node_modules/@eslint/compat": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.1.0.tgz",
-      "integrity": "sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^1.2.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "peerDependencies": {
-        "eslint": "^8.40 || 9 || 10"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@eslint/config-array": {
       "version": "0.23.5",
       "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
@@ -564,9 +542,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2452,16 +2430,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
-      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/config-helpers": "^0.6.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",

--- a/package.json
+++ b/package.json
@@ -37,12 +37,11 @@
   },
   "devDependencies": {
     "@effect/language-service": "^0.86.1",
-    "@eslint/compat": "^2.0.5",
     "@eslint/js": "^10.0.1",
     "@types/mdast": "^4.0.4",
     "@types/node": "^22.19.17",
     "conventional-commits-parser": "^6.4.0",
-    "eslint": "^10.3.0",
+    "eslint": "^10.4.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import-x": "^4.16.2",


### PR DESCRIPTION
`@eslint/compat`の`includeIgnoreFile`は、
[eslint/rewrite#329](https://github.com/eslint/rewrite/issues/329)
でdeprecatedとなり、
`@eslint/config-helpers`(`eslint/config`から再エクスポート)への移行が公式に推奨されました。
これに従い、import元を切り替えます。

副次的な変更:

- 新APIで導入された`gitignoreResolution: true`を指定します。
  これによりignoreパターンをignoreファイル自身からの相対パスとして解決する本来のgitignore挙動になり、
  モノレポ等でサブディレクトリの`.gitignore`を扱う際の挙動が改善されます。
- `eslint/config`から`includeIgnoreFile`が再エクスポートされるのは`eslint@10.4.0`以降なので、
  `eslint`を`10.3.0`から`10.4.0`に上げました。
- 直接の依存先が無くなったため、`@eslint/compat`を`devDependencies`から削除しました。
