### PR TITLE
refactor(body-line-break-punctuation): when=alwaysのみをサポート

### DIFF
--- a/src/@commitlint/rules/body-line-break-punctuation/index.ts
+++ b/src/@commitlint/rules/body-line-break-punctuation/index.ts
@@ -11,21 +11,13 @@ import { hasNoMidLinePunctuation } from "./mid-line-punctuation";
 const defaultTerminator = /(?:[\p{P}`])$/u;
 
 /** 個別の行が違反であるかを判定する。 */
-function isLineViolation(line: string, negated: boolean, anchoredTerminator: RegExp): boolean {
-  const endsWithTerminator = anchoredTerminator.test(line);
-  if (negated) {
-    return endsWithTerminator;
-  }
-  return !endsWithTerminator || !hasNoMidLinePunctuation(line);
+function isLineViolation(line: string, anchoredTerminator: RegExp): boolean {
+  return !anchoredTerminator.test(line) || !hasNoMidLinePunctuation(line);
 }
 
 /** 文字列から違反行を取り出す。 */
-function selectViolations(
-  body: string,
-  negated: boolean,
-  anchoredTerminator: RegExp,
-): readonly string[] {
-  return extractLines(body).filter((line) => isLineViolation(line, negated, anchoredTerminator));
+function selectViolations(body: string, anchoredTerminator: RegExp): readonly string[] {
+  return extractLines(body).filter((line) => isLineViolation(line, anchoredTerminator));
 }
 
 /**
@@ -44,35 +36,33 @@ function selectViolations(
  * リスト項目直後の行は遅延継続でリスト項目内に取り込まれるため対象外となる。
  * 段落内の`inlineCode`(バッククオート囲み)の中身も中間句読点判定の対象外となる。
  *
- * `when="never"`: 行末が`anchoredTerminator`で終わる行を違反とする。
- * neverモードの実用性が全く分からないので、
- * 一応慣習に従って実装はしますが、
- * 真面目に検査していません。
+ * `when`は`always`のみをサポートし、それ以外が指定された場合は例外を投げる。
  */
 export const bodyLineBreakPunctuation: SyncRule<RegExp> = (
   parsed,
   when = "always",
   anchoredTerminator = defaultTerminator,
 ) => {
+  if (when !== "always") {
+    throw new Error(`body-line-break-punctuation only supports when=always, but got when=${when}`);
+  }
+
   const body = parsed.body;
   if (body == null || body === "") {
     return [true];
   }
 
-  const negated = when === "never";
-
-  const violations = selectViolations(body, negated, anchoredTerminator);
+  const violations = selectViolations(body, anchoredTerminator);
 
   if (violations.length === 0) {
     return [true];
   }
 
-  const verb = negated ? "must not" : "must";
   return [
     false,
     message([
       `body lines [${violations.join(" / ")}]`,
-      verb,
+      "must",
       "end with punctuation and break after sentences",
     ]),
   ];

--- a/test/@commitlint/rules/body-line-break-punctuation.test.ts
+++ b/test/@commitlint/rules/body-line-break-punctuation.test.ts
@@ -279,12 +279,8 @@ second part.`;
     );
   });
 
-  it("neverメッセージは`must not`を含む指定の構造を持ちます。", () => {
-    const [valid, msg] = bodyLineBreakPunctuation(buildCommit("ends with period."), "never");
-    expect(valid).toBe(false);
-    expect(msg).toBe(
-      "body lines [ends with period.] must not end with punctuation and break after sentences",
-    );
+  it("when=always以外は未サポートで例外を投げます。", () => {
+    expect(() => bodyLineBreakPunctuation(buildCommit("ends with period."), "never")).toThrow();
   });
 
   it("カスタム正規表現で句点のみ許可するとカンマ終わりはfailします。", () => {
@@ -293,21 +289,6 @@ second part.`;
 next line.`;
     const [valid] = bodyLineBreakPunctuation(buildCommit(body), "always", onlyPeriod);
     expect(valid).toBe(false);
-  });
-
-  it("when=neverでは句読点で終わる行が違反になります。", () => {
-    const body = `ends with period.
-next line.`;
-    const [valid] = bodyLineBreakPunctuation(buildCommit(body), "never");
-    expect(valid).toBe(false);
-  });
-
-  it("when=neverで句読点なしの行はpassします。", () => {
-    const body = `no punctuation
-next line`;
-    const [valid, msg] = bodyLineBreakPunctuation(buildCommit(body), "never");
-    expect(msg).toBeUndefined();
-    expect(valid).toBe(true);
   });
 
   it("句点が行の途中にあるとfailします。", () => {


### PR DESCRIPTION
`bodyLineBreakPunctuation`は`when="never"`にも対応していましたが、
neverモードは実用性が不明な上に真面目に検査もしていませんでした。
中途半端にサポートを残すよりも明確に弾く方が安全なため、
`when`が`always`以外なら例外を投げるようにします。

これに伴い`negated`を引き回していた`isLineViolation`と`selectViolations`から、
分岐を取り除いて`always`専用のロジックに簡略化しました。
`verb`の`must`/`must not`分岐も不要になったため`must`固定にしています。

テストもneverの挙動を検証していたケースを削除し、
`always`以外で例外を投げることを検証するケースに置き換えました。
