### PR TITLE
style: flakeのoutputs引数で`self`を先頭に移動

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,8 +12,8 @@
 
   outputs =
     inputs@{
-      flake-parts,
       self,
+      flake-parts,
       treefmt-nix,
       ...
     }:


### PR DESCRIPTION
`self`はflake自身を指す特別な引数なので、
外部inputsである`flake-parts`や`treefmt-nix`より先頭に置くほうが、
役割の区別が分かりやすくなります。
動作に影響はない並び順のみの変更です。
