### PR TITLE
feat: Git LFSのhooksへ委譲して`core.hooksPath`固定環境でLFSを動作させる

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,23 @@ home-managerのmodulesとして有効化します。
 ## 含まれるhooks
 
 - `commit-msg`: [commitlint](https://commitlint.js.org/)によるコミットメッセージの検証
-- `post-merge`: マージ済みブランチの自動削除
+- `post-checkout`: `git lfs post-checkout`への委譲
+- `post-commit`: `git lfs post-commit`への委譲
+- `post-merge`: `git lfs post-merge`への委譲とマージ済みブランチの自動削除
+- `pre-push`: `git lfs pre-push`への委譲
+
+## Git LFSとの関係
+
+`core.hooksPath`を共通hooksへ固定すると、
+`git lfs install`が`.git/hooks`へ設置するhooksは実行されなくなります。
+その代わりに上記のhooksが同名の`git lfs`サブコマンドへ委譲することで、
+LFSを使うリポジトリでも通常通り動作します。
+hooksは`git-lfs`をPATHに含めてラップされているため、
+利用側で別途git-lfsをインストールする必要はありません。
+
+LFSを使わないリポジトリでは`git lfs`のhookサブコマンドは即座に何もせず終了するので、
+リポジトリごとの設定は不要です。
+
+なお`git lfs install`が行うもう1つの仕事である`filter.lfs.*`の設定は、
+このリポジトリの管轄外です。
+home-managerでは`programs.git.lfs.enable = true;`を設定してください。

--- a/flake.nix
+++ b/flake.nix
@@ -117,12 +117,16 @@
 
             postFixup = ''
               for exec in $out/lib/git-hooks/dist/hooks/commit-msg \
-                          $out/lib/git-hooks/dist/hooks/post-merge; do
+                          $out/lib/git-hooks/dist/hooks/post-checkout \
+                          $out/lib/git-hooks/dist/hooks/post-commit \
+                          $out/lib/git-hooks/dist/hooks/post-merge \
+                          $out/lib/git-hooks/dist/hooks/pre-push; do
                 wrapProgram "$exec" --prefix PATH : ${
                   lib.makeBinPath (
                     with pkgs;
                     [
                       git
+                      git-lfs
                       nodejs
                     ]
                   )

--- a/src/git-lfs.ts
+++ b/src/git-lfs.ts
@@ -1,0 +1,65 @@
+import { Command, CommandExecutor, Error as PlatformError } from "@effect/platform";
+import { Data, Effect } from "effect";
+
+/**
+ * `git lfs`サブコマンドの起動・実行自体が`PlatformError`で失敗した場合のエラー。
+ * `cause`に元の`PlatformError`を保持し、`args`に実行しようとした引数列を構造化して持つ。
+ */
+export class GitLfsCommandFailure extends Data.TaggedError("GitLfsCommandFailure")<{
+  readonly args: readonly string[];
+  readonly cause: PlatformError.PlatformError;
+}> {
+  override get message(): string {
+    return `git ${this.args.join(" ")}: ${this.cause.message}`;
+  }
+}
+
+/**
+ * `git lfs`サブコマンドが起動はしたが非0で終了した場合のエラー。
+ * git-lfs自身が詳細を標準エラー出力へ書くため、ここでは引数列と終了コードだけを持つ。
+ */
+export class GitLfsNonZeroExit extends Data.TaggedError("GitLfsNonZeroExit")<{
+  readonly args: readonly string[];
+  readonly exitCode: number;
+}> {
+  override get message(): string {
+    return `git ${this.args.join(" ")} exited with code ${this.exitCode}`;
+  }
+}
+
+/** このモジュールが返し得るエラーの全集合。 */
+export type GitLfsHookError = GitLfsCommandFailure | GitLfsNonZeroExit;
+
+/** git-lfsが`git lfs install`で`.git/hooks`へ設置するhookの名前。 */
+export type GitLfsHookName = "post-checkout" | "post-commit" | "post-merge" | "pre-push";
+
+/**
+ * Gitから渡されたhook引数をそのまま`git lfs <hook>`へ委譲する。
+ *
+ * `core.hooksPath`で共通hooksを固定すると、
+ * git-lfsが`.git/hooks`へ設置するhookは実行されなくなる。
+ * そのため共通hooks側からgit-lfsの同名hookを呼び出してLFSの動作を維持する。
+ *
+ * pre-pushはpush対象のref一覧を標準入力から受け取るため、
+ * 標準入出力はすべて親プロセスから継承する。
+ * LFSを使っていないリポジトリではgit-lfsが即座に何もせず正常終了するので、
+ * リポジトリごとの分岐は不要。
+ */
+export const delegateToGitLfs = (
+  hook: GitLfsHookName,
+  forwarded: readonly string[],
+): Effect.Effect<void, GitLfsHookError, CommandExecutor.CommandExecutor> =>
+  Effect.gen(function* () {
+    const args = ["lfs", hook, ...forwarded];
+    const cmd = Command.make("git", ...args).pipe(
+      Command.stdin("inherit"),
+      Command.stdout("inherit"),
+      Command.stderr("inherit"),
+    );
+    const code = yield* Command.exitCode(cmd).pipe(
+      Effect.mapError((cause) => new GitLfsCommandFailure({ args, cause })),
+    );
+    if (code !== 0) {
+      return yield* new GitLfsNonZeroExit({ args, exitCode: code });
+    }
+  });

--- a/src/hooks/post-checkout.ts
+++ b/src/hooks/post-checkout.ts
@@ -3,13 +3,12 @@ import { Args, Command as CliCommand } from "@effect/cli";
 import type { CommandExecutor } from "@effect/platform";
 import { NodeContext, NodeRuntime } from "@effect/platform-node";
 import { Console, Effect } from "effect";
-import { deleteMergedBranch, type DeleteMergedBranchError } from "../delete-merged-branch";
 import { delegateToGitLfs, type GitLfsHookError } from "../git-lfs";
 
 /**
  * Gitから渡される位置引数を吸収する定義。
- * post-mergeフックは`is_squash_merge`フラグを引数として渡してくる。
- * git-lfsへの委譲ではそのまま転送し、削除処理本体では参照しない。
+ * post-checkoutフックは移動前後のrefとブランチ切り替えフラグを引数として渡してくるので、
+ * そのままgit-lfsへ転送する。
  */
 const forwardedArgs = Args.text({ name: "forwarded-args" }).pipe(Args.repeated);
 
@@ -18,20 +17,15 @@ const handle = ({
   args,
 }: {
   readonly args: readonly string[];
-}): Effect.Effect<
-  void,
-  DeleteMergedBranchError | GitLfsHookError,
-  CommandExecutor.CommandExecutor
-> =>
-  delegateToGitLfs("post-merge", args).pipe(
-    Effect.andThen(deleteMergedBranch),
+}): Effect.Effect<void, GitLfsHookError, CommandExecutor.CommandExecutor> =>
+  delegateToGitLfs("post-checkout", args).pipe(
     Effect.tapError((err) => Console.error(err.message)),
   );
 
-/** post-mergeフック本体のCLI定義。 */
-const command = CliCommand.make("post-merge", { args: forwardedArgs }, handle);
+/** post-checkoutフック本体のCLI定義。 */
+const command = CliCommand.make("post-checkout", { args: forwardedArgs }, handle);
 
 /** `argv`を受け取って起動するCLI実行関数。 */
-const cli = CliCommand.run(command, { name: "post-merge", version: "0.0.0" });
+const cli = CliCommand.run(command, { name: "post-checkout", version: "0.0.0" });
 
 NodeRuntime.runMain(cli(argv).pipe(Effect.provide(NodeContext.layer)));

--- a/src/hooks/post-commit.ts
+++ b/src/hooks/post-commit.ts
@@ -3,13 +3,12 @@ import { Args, Command as CliCommand } from "@effect/cli";
 import type { CommandExecutor } from "@effect/platform";
 import { NodeContext, NodeRuntime } from "@effect/platform-node";
 import { Console, Effect } from "effect";
-import { deleteMergedBranch, type DeleteMergedBranchError } from "../delete-merged-branch";
 import { delegateToGitLfs, type GitLfsHookError } from "../git-lfs";
 
 /**
  * Gitから渡される位置引数を吸収する定義。
- * post-mergeフックは`is_squash_merge`フラグを引数として渡してくる。
- * git-lfsへの委譲ではそのまま転送し、削除処理本体では参照しない。
+ * post-commitフックは現状引数を渡してこないが、
+ * 将来の変更にも追従できるよう受け取ったものをそのままgit-lfsへ転送する。
  */
 const forwardedArgs = Args.text({ name: "forwarded-args" }).pipe(Args.repeated);
 
@@ -18,20 +17,13 @@ const handle = ({
   args,
 }: {
   readonly args: readonly string[];
-}): Effect.Effect<
-  void,
-  DeleteMergedBranchError | GitLfsHookError,
-  CommandExecutor.CommandExecutor
-> =>
-  delegateToGitLfs("post-merge", args).pipe(
-    Effect.andThen(deleteMergedBranch),
-    Effect.tapError((err) => Console.error(err.message)),
-  );
+}): Effect.Effect<void, GitLfsHookError, CommandExecutor.CommandExecutor> =>
+  delegateToGitLfs("post-commit", args).pipe(Effect.tapError((err) => Console.error(err.message)));
 
-/** post-mergeフック本体のCLI定義。 */
-const command = CliCommand.make("post-merge", { args: forwardedArgs }, handle);
+/** post-commitフック本体のCLI定義。 */
+const command = CliCommand.make("post-commit", { args: forwardedArgs }, handle);
 
 /** `argv`を受け取って起動するCLI実行関数。 */
-const cli = CliCommand.run(command, { name: "post-merge", version: "0.0.0" });
+const cli = CliCommand.run(command, { name: "post-commit", version: "0.0.0" });
 
 NodeRuntime.runMain(cli(argv).pipe(Effect.provide(NodeContext.layer)));

--- a/src/hooks/pre-push.ts
+++ b/src/hooks/pre-push.ts
@@ -3,13 +3,12 @@ import { Args, Command as CliCommand } from "@effect/cli";
 import type { CommandExecutor } from "@effect/platform";
 import { NodeContext, NodeRuntime } from "@effect/platform-node";
 import { Console, Effect } from "effect";
-import { deleteMergedBranch, type DeleteMergedBranchError } from "../delete-merged-branch";
 import { delegateToGitLfs, type GitLfsHookError } from "../git-lfs";
 
 /**
  * Gitから渡される位置引数を吸収する定義。
- * post-mergeフックは`is_squash_merge`フラグを引数として渡してくる。
- * git-lfsへの委譲ではそのまま転送し、削除処理本体では参照しない。
+ * pre-pushフックはリモート名とURLを引数として渡してくるので、
+ * そのままgit-lfsへ転送する。
  */
 const forwardedArgs = Args.text({ name: "forwarded-args" }).pipe(Args.repeated);
 
@@ -18,20 +17,13 @@ const handle = ({
   args,
 }: {
   readonly args: readonly string[];
-}): Effect.Effect<
-  void,
-  DeleteMergedBranchError | GitLfsHookError,
-  CommandExecutor.CommandExecutor
-> =>
-  delegateToGitLfs("post-merge", args).pipe(
-    Effect.andThen(deleteMergedBranch),
-    Effect.tapError((err) => Console.error(err.message)),
-  );
+}): Effect.Effect<void, GitLfsHookError, CommandExecutor.CommandExecutor> =>
+  delegateToGitLfs("pre-push", args).pipe(Effect.tapError((err) => Console.error(err.message)));
 
-/** post-mergeフック本体のCLI定義。 */
-const command = CliCommand.make("post-merge", { args: forwardedArgs }, handle);
+/** pre-pushフック本体のCLI定義。 */
+const command = CliCommand.make("pre-push", { args: forwardedArgs }, handle);
 
 /** `argv`を受け取って起動するCLI実行関数。 */
-const cli = CliCommand.run(command, { name: "post-merge", version: "0.0.0" });
+const cli = CliCommand.run(command, { name: "pre-push", version: "0.0.0" });
 
 NodeRuntime.runMain(cli(argv).pipe(Effect.provide(NodeContext.layer)));

--- a/test/git-lfs.test.ts
+++ b/test/git-lfs.test.ts
@@ -1,0 +1,106 @@
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { env } from "node:process";
+import { NodeContext } from "@effect/platform-node";
+import { Cause, Effect, Exit } from "effect";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { delegateToGitLfs, GitLfsNonZeroExit, type GitLfsHookName } from "../src/git-lfs";
+
+/**
+ * 本物のgitの代わりに呼び出しを記録する偽の`git`実行ファイルを生成する。
+ * 受け取った引数を`FAKE_GIT_RECORD`のファイルへ1行1引数で書き出し、
+ * `FAKE_GIT_EXIT`が設定されていればその終了コードで終了する。
+ */
+const installFakeGit = (dir: string): void => {
+  const script = join(dir, "git");
+  writeFileSync(
+    script,
+    [
+      "#!/bin/sh",
+      'printf "%s\\n" "$@" > "$FAKE_GIT_RECORD"',
+      'exit "${FAKE_GIT_EXIT:-0}"',
+      "",
+    ].join("\n"),
+  );
+  chmodSync(script, 0o755);
+};
+
+/** 偽gitが記録した引数列を読み出す。 */
+const recordedArgs = (recordFile: string): readonly string[] =>
+  readFileSync(recordFile, "utf8")
+    .split("\n")
+    .filter((line) => 0 < line.length);
+
+/** Effectを実行する補助。`NodeContext`を提供する。 */
+const run = (hook: GitLfsHookName, args: readonly string[]): Promise<Exit.Exit<void, unknown>> =>
+  Effect.runPromiseExit(delegateToGitLfs(hook, args).pipe(Effect.provide(NodeContext.layer)));
+
+describe("delegateToGitLfs", () => {
+  let root: string;
+  let recordFile: string;
+  let originalPath: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "git-lfs-hook-"));
+    recordFile = join(root, "record");
+    installFakeGit(root);
+    originalPath = env["PATH"];
+    env["PATH"] = `${root}:${env["PATH"] ?? ""}`;
+    env["FAKE_GIT_RECORD"] = recordFile;
+  });
+
+  afterEach(() => {
+    env["PATH"] = originalPath;
+    delete env["FAKE_GIT_RECORD"];
+    delete env["FAKE_GIT_EXIT"];
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("hook名と引数をそのまま`git lfs`へ転送する。", async () => {
+    const exit = await run("pre-push", ["origin", "https://example.com/repo.git"]);
+    expect(Exit.isSuccess(exit)).toBe(true);
+    expect(recordedArgs(recordFile)).toEqual([
+      "lfs",
+      "pre-push",
+      "origin",
+      "https://example.com/repo.git",
+    ]);
+  });
+
+  it("引数が無いhookでも`git lfs <hook>`だけで呼び出す。", async () => {
+    const exit = await run("post-commit", []);
+    expect(Exit.isSuccess(exit)).toBe(true);
+    expect(recordedArgs(recordFile)).toEqual(["lfs", "post-commit"]);
+  });
+
+  it("git-lfsが非0で終了した場合は`GitLfsNonZeroExit`で失敗する。", async () => {
+    env["FAKE_GIT_EXIT"] = "2";
+    const exit = await run("post-checkout", ["0000", "ffff", "1"]);
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const failure = Cause.failureOption(exit.cause);
+      expect(failure._tag).toBe("Some");
+      if (failure._tag === "Some") {
+        expect(failure.value).toBeInstanceOf(GitLfsNonZeroExit);
+        expect(failure.value).toMatchObject({
+          args: ["lfs", "post-checkout", "0000", "ffff", "1"],
+          exitCode: 2,
+        });
+      }
+    }
+  });
+});
+
+describe("git-lfsのエラー型", () => {
+  it("GitLfsNonZeroExitの`message`は引数列と終了コードを含む。", () => {
+    const err = new GitLfsNonZeroExit({
+      args: ["lfs", "pre-push", "origin"],
+      exitCode: 2,
+    });
+    expect(err.message).toBe("git lfs pre-push origin exited with code 2");
+    expect(err._tag).toBe("GitLfsNonZeroExit");
+    expect(err.args).toEqual(["lfs", "pre-push", "origin"]);
+    expect(err.exitCode).toBe(2);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,10 @@ const { rootDir, inputs } = Effect.runSync(
       rootDir,
       inputs: {
         "commit-msg": path.join(rootDir, "src/hooks/commit-msg.ts"),
+        "post-checkout": path.join(rootDir, "src/hooks/post-checkout.ts"),
+        "post-commit": path.join(rootDir, "src/hooks/post-commit.ts"),
         "post-merge": path.join(rootDir, "src/hooks/post-merge.ts"),
+        "pre-push": path.join(rootDir, "src/hooks/pre-push.ts"),
       },
     };
   }).pipe(Effect.provide(NodeContext.layer)),


### PR DESCRIPTION
home-managerで`core.hooksPath`を共通hooksへ固定すると、
`git lfs install`が`.git/hooks`へ設置するhooksは実行されなくなり、
LFSを使うリポジトリでpush時のオブジェクト転送などが行われなくなります。

そこで共通hooks側から同名の`git lfs`サブコマンドへ委譲する`delegateToGitLfs`を追加し、
`pre-push`と`post-checkout`と`post-commit`のhooksを新設しました。
既存の`post-merge`もマージ済みブランチ削除の前に`git lfs post-merge`へ委譲します。

`pre-push`はpush対象のref一覧を標準入力から受け取るため、
標準入出力はすべて親プロセスから継承します。
LFSを使わないリポジトリではgit-lfsが即座に何もせず正常終了するため、
リポジトリごとの分岐は設けていません。

Nixのwrapperには`git-lfs`をPATHへ追加し、
利用側で別途git-lfsをインストールしなくても動作するようにしました。
