### PR TITLE
feat: 英数字に挟まれたピリオドを単語内ピリオドとして許可する

### DIFF
--- a/src/@commitlint/rules/body-punctuation/mid-line-period.ts
+++ b/src/@commitlint/rules/body-punctuation/mid-line-period.ts
@@ -8,19 +8,60 @@ import * as C from "parser-ts/char";
 const periodChars = ".。．" as const;
 
 /**
- * 句点ではない文字を1文字以上連続で消費し、消費した文字列を返す。
- * 読点を含む句点以外の文字を全て消費するので、句点判定では読点は無害扱いになる。
- * 1ステップで可能な限り長くマッチさせるため、1文字単位ではなく文字列単位の処理になる。
+ * 単語内ピリオドの許可対象となる文字(ASCII英数字)の判定。
+ * `Node.js`のようなコードネームや`9.12`のようなバージョン番号・数値を構成する。
+ * 日本語文の区切りに使われた半角ピリオドまで許可しないよう、ASCIIに限定する。
  */
-const safeRun: P.Parser<C.Char, string> = C.many1(C.notOneOf(periodChars));
+function isWordChar(char: C.Char): boolean {
+  return /^[0-9A-Za-z]$/.test(char);
+}
+
+/** ASCII英数字を1文字以上連続で消費し、消費した文字列を返す。 */
+const wordRun: P.Parser<C.Char, string> = C.many1(
+  P.expected(P.sat(isWordChar), "an ascii alphanumeric character"),
+);
+
+/**
+ * 単語内ピリオドとその後続の英数字列を消費する。
+ * ピリオドの直後に英数字が続かない場合は失敗し、
+ * バックトラックによってピリオドは消費されなかったことになる。
+ */
+const wordDot: P.Parser<C.Char, string> = pipe(
+  C.char("."),
+  P.chain(() => wordRun),
+);
+
+/**
+ * 英数字列を、英数字に挟まれた半角ピリオドで連結した「単語」を消費する。
+ * `Node.js`、`GHC 9.12`の`9.12`、`1.5倍`の`1.5`などがこれに該当する。
+ * 全角句点(`。`/`．`)は単語内であっても許可しない。
+ */
+const word: P.Parser<C.Char, string> = pipe(
+  wordRun,
+  P.chainFirst(() => P.many(wordDot)),
+);
+
+/**
+ * 句点でも単語構成文字でもない文字を1文字以上連続で消費し、消費した文字列を返す。
+ * 読点を含む句点以外の文字を全て消費するので、句点判定では読点は無害扱いになる。
+ * 単語構成文字を除外するのは、単語の先頭を先に消費してしまうと
+ * `word`パーサが単語内ピリオドを判定できなくなるためです。
+ */
+const plainRun: P.Parser<C.Char, string> = C.many1(
+  P.expected(
+    P.sat<C.Char>((char) => !periodChars.includes(char) && !isWordChar(char)),
+    "a character that is neither a period nor a word character",
+  ),
+);
 
 /**
  * 「中間句点なし」の行を読み切るパーサ。
- * 句点以外を0回以上消費した後、最終1文字を任意に消費して終わる(空行も許容)。
- * 句点に閾値許容は無いため、中間に句点が現れた時点で失敗する。
+ * 単語(単語内ピリオドを許容)とそれ以外の安全な文字列を0回以上消費した後、
+ * 最終1文字を任意に消費して終わる(空行も許容)。
+ * 単語内ピリオドを除き、中間に句点が現れた時点で失敗する。
  */
 const noMidLinePeriod: P.Parser<C.Char, void> = pipe(
-  P.many(safeRun),
+  P.many(P.either(word, () => plainRun)),
   P.chain(() =>
     P.either(
       pipe(
@@ -37,7 +78,7 @@ const noMidLinePeriod: P.Parser<C.Char, void> = pipe(
   ),
 );
 
-/** 行の途中に句点が含まれるかを判定する。 */
+/** 行の途中に句点(単語内ピリオドを除く)が含まれるかを判定する。 */
 export function hasMidLinePeriod(line: string): boolean {
   return !isRight(noMidLinePeriod(stream(Array.from(line))));
 }

--- a/src/@commitlint/rules/period-needs-break.ts
+++ b/src/@commitlint/rules/period-needs-break.ts
@@ -10,6 +10,8 @@ import { hasMidLinePeriod } from "./body-punctuation/mid-line-period";
  *
  * `when="always"`: 各行は行の途中に句点(`.`/`。`/`．`)を含まないことが要求される。
  * 行末の句点は許容され、中間に句点が現れた時点で違反となる。
+ * ただし`Node.js`のようなコードネームや`9.12`のようなバージョン番号・数値のために、
+ * ASCII英数字に挟まれた半角ピリオドは単語内ピリオドとして許容される。
  * 読点は別ルール`body-comma-needs-break`の担当であり、ここでは無害文字として扱う。
  *
  * 検査対象はmdast上の段落(`paragraph`ノード)に限られる。

--- a/test/@commitlint/rules/period-needs-break.test.ts
+++ b/test/@commitlint/rules/period-needs-break.test.ts
@@ -60,6 +60,54 @@ Third line.`;
     expect(valid).toBe(false);
   });
 
+  it("コードネーム内のピリオドは中間句点として扱われません。", () => {
+    const [valid, msg] = periodNeedsBreak(buildCommit("Node.jsのバージョンを更新する。"), "always");
+    expect(msg).toBeUndefined();
+    expect(valid).toBe(true);
+  });
+
+  it("バージョン番号内のピリオドは中間句点として扱われません。", () => {
+    const [valid, msg] = periodNeedsBreak(buildCommit("GHC 9.12に更新する。"), "always");
+    expect(msg).toBeUndefined();
+    expect(valid).toBe(true);
+  });
+
+  it("数値の小数点は中間句点として扱われません。", () => {
+    const [valid, msg] = periodNeedsBreak(buildCommit("処理速度が1.5倍になる。"), "always");
+    expect(msg).toBeUndefined();
+    expect(valid).toBe(true);
+  });
+
+  it("単語内ピリオドが複数あってもpassします。", () => {
+    const [valid, msg] = periodNeedsBreak(
+      buildCommit("Node.jsとGHC 9.12で速度が1.5倍になる。"),
+      "always",
+    );
+    expect(msg).toBeUndefined();
+    expect(valid).toBe(true);
+  });
+
+  it("単語内ピリオドを含む単語で始まる行もpassします。", () => {
+    const [valid, msg] = periodNeedsBreak(buildCommit("1.5倍の速度になる。"), "always");
+    expect(msg).toBeUndefined();
+    expect(valid).toBe(true);
+  });
+
+  it("非ASCII文字に挟まれた半角ピリオドはfailします。", () => {
+    const [valid] = periodNeedsBreak(buildCommit("1文目です.2文目です。"), "always");
+    expect(valid).toBe(false);
+  });
+
+  it("英数字に挟まれていても全角句点はfailします。", () => {
+    const [valid] = periodNeedsBreak(buildCommit("Node。jsを更新する。"), "always");
+    expect(valid).toBe(false);
+  });
+
+  it("ピリオドの後に空白が続く場合はfailします。", () => {
+    const [valid] = periodNeedsBreak(buildCommit("Update Node.js. And more."), "always");
+    expect(valid).toBe(false);
+  });
+
   it("読点が行の途中にあっても句点観点ではpassします。", () => {
     const [valid, msg] = periodNeedsBreak(
       buildCommit("とても長い前置きを書いた後で、続きを書きます。"),


### PR DESCRIPTION
`body-period-needs-break`ルールは行の途中の半角ピリオドを一律で違反にしていたため、
`Node.js`のようなコードネームや`GHC 9.12`のようなバージョン番号、
`1.5倍`のような数値をコミットメッセージ本文に書けませんでした。
毎回インラインコードで囲む回避策は文章として不自然なので、
これらを違反にしないようにします。

`hasMidLinePeriod`のパーサに、
英数字列を英数字に挟まれた半角ピリオドで連結した「単語」を消費する`word`パーサを追加し、
既存の安全文字列パーサは句点と単語構成文字の両方を除外する`plainRun`に変更しました。
単語の先頭を`plainRun`が先に消費してしまうと単語内ピリオドを判定できなくなるためです。

許可対象はASCII英数字に挟まれた半角ピリオドに限定しています。
ひらがななどもUnicodeのLetterに含まれるため、
Letter全般を対象にすると日本語文の区切りに使われた半角ピリオドまで素通りしてしまうからです。
全角句点(`。`/`．`)とピリオドの後に空白が続く文区切りは従来通り違反になります。

close #188

https://claude.ai/code/session_01WrZKaLAY3kFV2evgpf1Mvy