### PR TITLE
build(deps): effectモノレポ更新の`package-lock.json`を手動で再生成する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@commitlint/lint": "^21.2.0",
         "@commitlint/message": "^21.0.1",
         "@commitlint/types": "^21.0.0",
-        "@effect/cli": "^0.76.0",
+        "@effect/cli": "^0.77.0",
         "@effect/platform": "^0.97.0",
         "@effect/platform-node": "^0.108.0",
         "effect": "^3.22.0",
@@ -203,9 +203,9 @@
       }
     },
     "node_modules/@effect/cli": {
-      "version": "0.76.0",
-      "resolved": "https://registry.npmjs.org/@effect/cli/-/cli-0.76.0.tgz",
-      "integrity": "sha512-6N6u827Brlvf1UF3WMUazUgzZxq3kN/jemj66El7CUNulmlU7ciYKV0UMpETculvkKTfVonHZ5s49Fdz6Ad0cQ==",
+      "version": "0.77.0",
+      "resolved": "https://registry.npmjs.org/@effect/cli/-/cli-0.77.0.tgz",
+      "integrity": "sha512-uVw33bcqPaSu6YZqGf6MyM2CbYsE79mrAnQsDzSFnP8jmnjNfXWrfmWUGK2yy0jXD0wWmVbmvwm4xVFv2Utsog==",
       "license": "MIT",
       "dependencies": {
         "ini": "^4.1.3",
@@ -213,41 +213,41 @@
         "yaml": "^2.5.0"
       },
       "peerDependencies": {
-        "@effect/platform": "^0.97.0",
-        "@effect/printer": "^0.50.0",
-        "@effect/printer-ansi": "^0.50.0",
-        "effect": "^3.22.0"
+        "@effect/platform": "^0.97.1",
+        "@effect/printer": "^0.51.0",
+        "@effect/printer-ansi": "^0.51.0",
+        "effect": "^3.22.1"
       }
     },
     "node_modules/@effect/cluster": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@effect/cluster/-/cluster-0.60.0.tgz",
-      "integrity": "sha512-O98Qx8jzEBhizhV/nOiqkZx+b0kx0AB1FBX+AKJ8wR8XO5Le44jqFzBwhwcoOVRhKVr2wzp3OE+IthipCVh4Mg==",
+      "version": "0.60.1",
+      "resolved": "https://registry.npmjs.org/@effect/cluster/-/cluster-0.60.1.tgz",
+      "integrity": "sha512-M1NUQ1TD2bd446LeHgqynxAxI6dExghX0glI15mM+kNu+37JGiJaGLxgnCW5z0QyxQ4o8bYBzt8IKuIP8N/Ydg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "kubernetes-types": "^1.30.0"
       },
       "peerDependencies": {
-        "@effect/platform": "^0.97.0",
-        "@effect/rpc": "^0.76.0",
-        "@effect/sql": "^0.52.0",
+        "@effect/platform": "^0.97.1",
+        "@effect/rpc": "^0.76.1",
+        "@effect/sql": "^0.52.1",
         "@effect/workflow": "^0.19.0",
-        "effect": "^3.22.0"
+        "effect": "^3.22.1"
       }
     },
     "node_modules/@effect/experimental": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@effect/experimental/-/experimental-0.61.0.tgz",
-      "integrity": "sha512-kv/ZORw2RMau74Q6Pco9/RTf/iXczBDqStHI9K8dP/1pUFq+dUMa4fHptuf3IIAe3tYdx4ALYsLyFLVcg+C5iQ==",
+      "version": "0.61.1",
+      "resolved": "https://registry.npmjs.org/@effect/experimental/-/experimental-0.61.1.tgz",
+      "integrity": "sha512-+P+PgGQeE2fXmsm63YoyENNcQIc7OiCkY4/HLkEdTvq93syfGIpwDfQD8u3xODMHJhZ5ZtRZHH4+UedFO0tLiA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "uuid": "^11.0.3"
       },
       "peerDependencies": {
-        "@effect/platform": "^0.97.0",
-        "effect": "^3.22.0",
+        "@effect/platform": "^0.97.1",
+        "effect": "^3.22.1",
         "ioredis": "^5",
         "lmdb": "^3"
       },
@@ -271,17 +271,17 @@
       }
     },
     "node_modules/@effect/platform": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.97.0.tgz",
-      "integrity": "sha512-PPSKkQ+QlIbKcf74FZKi3pi2h8hqYjsrUYaFuWXsuHpr8gjUoNNxJBptYzkzy4X9f7EeHhHqDMcj9YxaMygiHg==",
+      "version": "0.97.1",
+      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.97.1.tgz",
+      "integrity": "sha512-IevWxwmrxCdeXxbXDx/hiOstHtERRigd1nhZSuHgiFEl7NkBmS/5GVWsRacq4NfJN2uCXqggETKNwij15VEpew==",
       "license": "MIT",
       "dependencies": {
         "find-my-way-ts": "^0.1.6",
         "msgpackr": "^1.11.10",
-        "multipasta": "^0.2.7"
+        "multipasta": "^0.2.8"
       },
       "peerDependencies": {
-        "effect": "^3.22.0"
+        "effect": "^3.22.1"
       }
     },
     "node_modules/@effect/platform-node": {
@@ -304,75 +304,75 @@
       }
     },
     "node_modules/@effect/platform-node-shared": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-0.61.0.tgz",
-      "integrity": "sha512-68KbcnItrKFgDinFOmBVSABjcXBjp4vZbOUI3piFh87ZK/55vQ8+bwKGU4X7R9Vz1lSehyz5m2e7hwWVq3GNrg==",
+      "version": "0.61.1",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-0.61.1.tgz",
+      "integrity": "sha512-MJAJ1Nc43pYJb5ulFtdNID8klNyRLcbQ0zZ7XYRcBAlT/DrCyN4yAD89AzosmUyfOU+LMHdc8LTMt4rKNEMFaA==",
       "license": "MIT",
       "dependencies": {
         "@parcel/watcher": "^2.5.1",
-        "multipasta": "^0.2.7",
+        "multipasta": "^0.2.8",
         "ws": "^8.18.2"
       },
       "peerDependencies": {
-        "@effect/cluster": "^0.60.0",
-        "@effect/platform": "^0.97.0",
-        "@effect/rpc": "^0.76.0",
-        "@effect/sql": "^0.52.0",
-        "effect": "^3.22.0"
+        "@effect/cluster": "^0.60.1",
+        "@effect/platform": "^0.97.1",
+        "@effect/rpc": "^0.76.1",
+        "@effect/sql": "^0.52.1",
+        "effect": "^3.22.1"
       }
     },
     "node_modules/@effect/printer": {
-      "version": "0.50.0",
-      "resolved": "https://registry.npmjs.org/@effect/printer/-/printer-0.50.0.tgz",
-      "integrity": "sha512-9tV9tNJS+Mjw+ZkBrfX3oUw9Kj5Ay61XMq0sONIUiBc6IgmJnLRmS12D/GTCVYncVmcX9zVrllhvN99StdcETg==",
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@effect/printer/-/printer-0.51.0.tgz",
+      "integrity": "sha512-TdUPaEKwLbo9lpl+atjJvcQqNGM5/sH5Y+iulaLw3uvArHrZSx+HHwa0q0ptuNmOfuEG5j/RRAJHcKFmUyOi8Q==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@effect/typeclass": "^0.41.0",
-        "effect": "^3.22.0"
+        "effect": "^3.22.1"
       }
     },
     "node_modules/@effect/printer-ansi": {
-      "version": "0.50.0",
-      "resolved": "https://registry.npmjs.org/@effect/printer-ansi/-/printer-ansi-0.50.0.tgz",
-      "integrity": "sha512-m2eVY1EcHRAQitweIcLUlZohRO4P96pyjiS8p31064CFddsY4qwXrP0I5h39T7D91gutM3Cru6VUDnw20rNyeA==",
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@effect/printer-ansi/-/printer-ansi-0.51.0.tgz",
+      "integrity": "sha512-tV36FU7q+3/avuctRl7Gt4u2RsVJ2x2b0n82s6SLUcXxDZ0G1dkE2feQL0UeSjPRZhgq36CaVAEDyhDPkSK8XQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@effect/printer": "^0.50.0"
+        "@effect/printer": "^0.51.0"
       },
       "peerDependencies": {
         "@effect/typeclass": "^0.41.0",
-        "effect": "^3.22.0"
+        "effect": "^3.22.1"
       }
     },
     "node_modules/@effect/rpc": {
-      "version": "0.76.0",
-      "resolved": "https://registry.npmjs.org/@effect/rpc/-/rpc-0.76.0.tgz",
-      "integrity": "sha512-51lcJtpy6ls9GnS6VqYBLeZq4xziUCHqdb/FkEDp9NO4WEIZfO+u/mfYUiAqMf3uiyr/GgrC1+JGIblf9Brqow==",
+      "version": "0.76.1",
+      "resolved": "https://registry.npmjs.org/@effect/rpc/-/rpc-0.76.1.tgz",
+      "integrity": "sha512-qZG4lhegYqIexoC/e82Z48vtBy0VkdyAp/8mEXi2i+GoedxO67zbbkxSoKhMG8GSglfLH9jRcMrmZrgFAynVWA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "msgpackr": "^1.11.10"
       },
       "peerDependencies": {
-        "@effect/platform": "^0.97.0",
-        "effect": "^3.22.0"
+        "@effect/platform": "^0.97.1",
+        "effect": "^3.22.1"
       }
     },
     "node_modules/@effect/sql": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@effect/sql/-/sql-0.52.0.tgz",
-      "integrity": "sha512-S7z9grD8QmuQDjM7VZLA3RsyQt9TKL/uSyjsz9Oz+gqBA4Espu+8dLDCc1OCWxVWUbUnfGH4L6rv4pSsX598iA==",
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@effect/sql/-/sql-0.52.1.tgz",
+      "integrity": "sha512-dUVPjlUgpga6sDa/MtYipHAqzHx2St41hxI00nXTBt4IBBJaf2lTGaOvlEoBg/q6PHVAgSoKnxe19pWUvabC9g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "uuid": "^11.0.3"
       },
       "peerDependencies": {
-        "@effect/experimental": "^0.61.0",
-        "@effect/platform": "^0.97.0",
-        "effect": "^3.22.0"
+        "@effect/experimental": "^0.61.1",
+        "@effect/platform": "^0.97.1",
+        "effect": "^3.22.1"
       }
     },
     "node_modules/@effect/typeclass": {
@@ -399,38 +399,35 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "2.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
-      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "2.0.1",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "2.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
-      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
-      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -715,9 +712,9 @@
       ]
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.0.tgz",
-      "integrity": "sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.1.tgz",
+      "integrity": "sha512-KjZdi8Q1wh89gsVmghvbrMgWl6ZWmRmHV6wjB7/g4Zf0dyO+hH3neZUtuDNPO00qq5YE5RITVWvrIZKRaAmzGQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -732,8 +729,8 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^2.0.0-alpha.3",
-        "@emnapi/runtime": "^2.0.0-alpha.3"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -1993,40 +1990,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
@@ -2451,9 +2414,9 @@
       }
     },
     "node_modules/effect": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.22.0.tgz",
-      "integrity": "sha512-jhYFe0zTlIRqYFrKTS+6luhmS/Tm0f+JLo0K9KUxvtFab1SUGEszQi2ehOP6QzAZvy831lDmTwwzvVDZSPNz3g==",
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.22.1.tgz",
+      "integrity": "sha512-TNoXushmPOBAjJlthF5d2QwnX2xBPEtcNJr5XKNKbRLbDvBcOYkXlYDfvGfSA0zriwLFuCll5MDtNMAdZL17PQ==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -2461,9 +2424,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.24.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
-      "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
+      "version": "5.24.4",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.4.tgz",
+      "integrity": "sha512-GVoi+ICHocoOIU7qVVM48wOJziRsqrsyqlI0Ce0LdowRn6v3bcH2zUa9kp85ncx0nwIb9/HOCOLS3fdThDG/XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4628,9 +4591,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
-      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@commitlint/lint": "^21.2.0",
     "@commitlint/message": "^21.0.1",
     "@commitlint/types": "^21.0.0",
-    "@effect/cli": "^0.76.0",
+    "@effect/cli": "^0.77.0",
     "@effect/platform": "^0.97.0",
     "@effect/platform-node": "^0.108.0",
     "effect": "^3.22.0",


### PR DESCRIPTION
renovateの[PR #223](https://github.com/ncaq/git-hooks/pull/223)が、
`package-lock.json`の更新に失敗していたため手動で更新します。

- `@effect/cli`: 0.76.0 → 0.77.0
- `@effect/platform`: 0.97.0 → 0.97.1
- `effect`: 3.22.0 → 3.22.1

失敗の原因は、
`@effect/cli` 0.77.0がpeer依存として`@effect/printer` ^0.51.0を要求する一方で、
ロックファイルに残った古い`@effect/printer` 0.50.0のエントリと競合して、
ERESOLVEエラーで解決に失敗することでした。
ローカルの通常の`npm install`でも同じエラーが再現しました。

そのため`package-lock.json`と`node_modules`を一旦削除してから、
`npm install`で再解決させることで、
`@effect/printer`系も0.51.0へ揃えて更新しました。

再生成後にdirenv経由でNixの`node_modules`を再構築し、
`tsc --noEmit`とvitestの全140件のテストが通ることを確認しています。

close #223

https://claude.ai/code/session_01Ku4iPRmWScy8mVQehAZrCC